### PR TITLE
docs: Include repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "W3C-20150513",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3c/webappsec-trusted-types.git"
+    "url": "https://github.com/w3c/trusted-types.git"
   }
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
   },
   "author": "Google Inc.",
   "license": "W3C-20150513",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/w3c/webappsec-trusted-types.git"
+  }
   "devDependencies": {
     "@babel/core": "^7.5.5",
     "@babel/polyfill": "^7.4.4",


### PR DESCRIPTION
That way people can discover the repository from https://www.npmjs.com/package/trusted-types.

See [`package.json` `repository` field documentation](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository)