### PR TITLE
Modify the script slot setting algorithms.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1189,9 +1189,18 @@ partial interface HTMLScriptElement {
 };
 </pre>
 
-On setting, the {{HTMLElement/innerText}}, {{Node/textContent}} and {{HTMLScriptElement/text}} IDL attributes perform the regular steps, and then set {{HTMLScriptElement/[[ScriptText]]}} internal slot value with the stringified value.
+On setting, the {{HTMLElement/innerText}}, {{Node/textContent}} and {{HTMLScriptElement/text}} IDL attributes execute the following algorithm:
 
-On setting, the {{HTMLScriptElement/src}} IDL attribute performs the usual steps, and then sets {{HTMLScriptElement/[[ScriptURL]]}} internal slot value to its <{script/src}> content attribute value.
+1. Set <var>previousValue</var> to {{HTMLScriptElement/[[ScriptText]]}} internal slot value.
+1. Set {{HTMLScriptElement/[[ScriptText]]}} internal slot value to the stringified attribute value.
+1. Perform the usual attribute setter steps. If the algorithm threw an error, set {{HTMLScriptElement/[[ScriptText]]}} internal slot value to <var>previousValue</var>.
+
+
+On setting, the {{HTMLScriptElement/src}} IDL attribute, execute the following algorithm:
+
+1. Set <var>previousValue</var> to {{HTMLScriptElement/[[ScriptURL]]}} internal slot value.
+1. Set {{HTMLScriptElement/[[ScriptURL]]}} internal slot value to the stringified attribute value.
+1. Perform the usual attribute setter steps.  If the algorithm threw an error, set {{HTMLScriptElement/[[ScriptURL]]}} internal slot value to <var>previousValue</var>.
 
 #### Slot value verification #### {#slot-value-verification}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1189,18 +1189,16 @@ partial interface HTMLScriptElement {
 };
 </pre>
 
-On setting, the {{HTMLElement/innerText}}, {{Node/textContent}} and {{HTMLScriptElement/text}} IDL attributes execute the following algorithm:
+On setting the {{HTMLElement/innerText}}, {{Node/textContent}} and {{HTMLScriptElement/text}} IDL attributes execute the following algorithm:
 
-1. Set <var>previousValue</var> to {{HTMLScriptElement/[[ScriptText]]}} internal slot value.
 1. Set {{HTMLScriptElement/[[ScriptText]]}} internal slot value to the stringified attribute value.
-1. Perform the usual attribute setter steps. If the algorithm threw an error, set {{HTMLScriptElement/[[ScriptText]]}} internal slot value to <var>previousValue</var>.
+1. Perform the usual attribute setter steps.
 
 
-On setting, the {{HTMLScriptElement/src}} IDL attribute, execute the following algorithm:
+On setting the {{HTMLScriptElement/src}} IDL attribute, execute the following algorithm:
 
-1. Set <var>previousValue</var> to {{HTMLScriptElement/[[ScriptURL]]}} internal slot value.
 1. Set {{HTMLScriptElement/[[ScriptURL]]}} internal slot value to the stringified attribute value.
-1. Perform the usual attribute setter steps.  If the algorithm threw an error, set {{HTMLScriptElement/[[ScriptURL]]}} internal slot value to <var>previousValue</var>.
+1. Perform the usual attribute setter steps.
 
 #### Slot value verification #### {#slot-value-verification}
 


### PR DESCRIPTION
The slot value is now set before the IDL attribute setter is called.
That will make the 'prepare the script element' HTML algorithm receive the
new value, since that algorithm (which does TT checks) now executes immediately after modifying
the attribute: https://html.spec.whatwg.org/#script-processing-model:prepare-the-script-element-4