### PR TITLE
Update callback IDL to return nullable types

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -763,9 +763,9 @@ dictionary TrustedTypePolicyOptions {
    CreateScriptCallback? createScript;
    CreateScriptURLCallback? createScriptURL;
 };
-callback CreateHTMLCallback = DOMString (DOMString input, any... arguments);
-callback CreateScriptCallback = DOMString (DOMString input, any... arguments);
-callback CreateScriptURLCallback = USVString (DOMString input, any... arguments);
+callback CreateHTMLCallback = DOMString? (DOMString input, any... arguments);
+callback CreateScriptCallback = DOMString? (DOMString input, any... arguments);
+callback CreateScriptURLCallback = USVString? (DOMString input, any... arguments);
 </pre>
 
 ### <dfn>Default policy</dfn> ### {#default-policy-hdr}


### PR DESCRIPTION
Partially addresses #388 

Chromium is correct in terms of the nullability of the return types, without adding the nullability my implementation in WebKit fails tests that expect null to become "" not "null"