### PR TITLE
Add integration with setHTMLUnsafe and parseHTMLUnsafe

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1447,6 +1447,7 @@ This document modifies the following interfaces defined by [[DOM-Parsing]]:
 partial interface Element {
   [CEReactions, LegacyNullToEmptyString] attribute HTMLString outerHTML;
   [CEReactions] undefined insertAdjacentHTML(DOMString position, HTMLString text);
+  [CEReactions] undefined setHTMLUnsafe(HTMLString html);
 };
 
 partial interface mixin InnerHTML { // specified in a draft version at https://w3c.github.io/DOM-Parsing/#the-innerhtml-mixin
@@ -1457,10 +1458,18 @@ partial interface Range {
   [CEReactions, NewObject] DocumentFragment createContextualFragment(HTMLString fragment);
 };
 
+partial interface ShadowRoot {
+  [CEReactions] undefined setHTMLUnsafe(HTMLString html);
+};
+
 [Exposed=Window]
 interface DOMParser {
   constructor();
   [NewObject] Document parseFromString(HTMLString str, SupportedType type);
+};
+
+partial interface Document {
+  static Document parseHTMLUnsafe(HTMLString html);
 };
 </pre>
 


### PR DESCRIPTION
Fixes #403 

Couldn't seem to get the functions to link to the right place in the HTML spec. But none of the methods in the IDL are linking as expected so perhaps there's a deeper issue?