### PR TITLE
Remove pre-commit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,12 +62,6 @@
     "watchify": "^3.11.1"
   },
   "dependencies": {},
-  "pre-commit": [
-    "lint",
-    "test",
-    "build",
-    "add_build"
-  ],
   "files": [
     "build",
     "dist",


### PR DESCRIPTION
These make committing a pain as they never work.

The polyfill should be moved to a separate repo imo anyway. (https://github.com/w3c/trusted-types/issues/444)