### PR TITLE
Add example for CSP header with `'none'`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1616,6 +1616,13 @@ Content-Security-Policy: trusted-types; require-trusted-types-for 'script'
 </pre>
 </div>
 
+The keyword `'none'` may be used to explicitly express the above:
+<div class="example" id="header-with-none-that-allows-no-policy-names">
+<pre class="http">
+Content-Security-Policy: trusted-types 'none'; require-trusted-types-for 'script'
+</pre>
+</div>
+
 Keyword `'allow-duplicates'` allows for creating policies with a name that was already used.
 
 <div class="example" id="allow-duplicates-in-header">


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mbrodesser-Igalia/trusted-types/pull/453.html" title="Last updated on Feb 22, 2024, 2:10 PM UTC (ebdd02a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/453/4e858f8...mbrodesser-Igalia:ebdd02a.html" title="Last updated on Feb 22, 2024, 2:10 PM UTC (ebdd02a)">Diff</a>