### PR TITLE
Fix IDL of getAttributeType and getPropertyType

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -563,12 +563,12 @@ on the global object - see [[#extensions-to-the-windoworworkerglobalscope-interf
     DOMString? getAttributeType(
         DOMString tagName,
         DOMString attribute,
-        optional DOMString elementNs = "",
-        optional DOMString attrNs = "");
+        optional DOMString? elementNs = "",
+        optional DOMString? attrNs = "");
     DOMString? getPropertyType(
         DOMString tagName,
         DOMString property,
-        optional DOMString elementNs = "");
+        optional DOMString? elementNs = "");
     readonly attribute TrustedTypePolicy? defaultPolicy;
 };
 </pre>


### PR DESCRIPTION
- Makes namespace properties nullable DOMStrings


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/460.html" title="Last updated on Feb 28, 2024, 5:56 PM UTC (5f28cbc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/460/51d9e37...lukewarlow:5f28cbc.html" title="Last updated on Feb 28, 2024, 5:56 PM UTC (5f28cbc)">Diff</a>