### PR TITLE
Correct the location of some IDL

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1148,7 +1148,7 @@ partial interface mixin WindowOrWorkerGlobalScope {
 The {{WindowOrWorkerGlobalScope/trustedTypes}} getter steps are to return [=this=]'s [=relevant global object=]'s [[#integration-with-html|trusted
 type policy factory]].
 
-### Extensions to the Document interface ### {#extensions-to-the-document-interface}
+### Enforcement in the Document interface ### {#enforcement-in-document-interface}
 
 This document modifies the {{Document}} interface defined by [[HTML5|HTML]]:
 
@@ -1156,6 +1156,31 @@ This document modifies the {{Document}} interface defined by [[HTML5|HTML]]:
 partial interface Document {
   [CEReactions] undefined write(HTMLString... text);
   [CEReactions] undefined writeln(HTMLString... text);
+  static Document parseHTMLUnsafe(HTMLString html);
+};
+</pre>
+
+### Enforcement in DOMParser interface ### {#enforcement-in-domparser-interface}
+
+This document modifies the {{DOMParser}} interface defined by [[HTML5|HTML]]:
+
+<pre class="idl exclude">
+partial interface DOMParser {
+  [NewObject] Document parseFromString(HTMLString str, SupportedType type);
+};
+</pre>
+
+### Enforcement in the Element and ShadowRoot interfaces ### {#enforcement-in-element-shadowroot-interfaces}
+
+This document modifies the {{Element}} and {{ShadowRoot}} interfaces defined by [[HTML5|HTML]]:
+
+<pre class="idl exclude">
+partial interface Element {
+  [CEReactions] undefined setHTMLUnsafe(HTMLString html);
+};
+
+partial interface ShadowRoot {
+  [CEReactions] undefined setHTMLUnsafe(HTMLString html);
 };
 </pre>
 
@@ -1398,7 +1423,6 @@ This document modifies the following interfaces defined by [[DOM-Parsing]]:
 partial interface Element {
   [CEReactions, LegacyNullToEmptyString] attribute HTMLString outerHTML;
   [CEReactions] undefined insertAdjacentHTML(DOMString position, HTMLString text);
-  [CEReactions] undefined setHTMLUnsafe(HTMLString html);
 };
 
 partial interface mixin InnerHTML { // specified in a draft version at https://w3c.github.io/DOM-Parsing/#the-innerhtml-mixin
@@ -1407,20 +1431,6 @@ partial interface mixin InnerHTML { // specified in a draft version at https://w
 
 partial interface Range {
   [CEReactions, NewObject] DocumentFragment createContextualFragment(HTMLString fragment);
-};
-
-partial interface ShadowRoot {
-  [CEReactions] undefined setHTMLUnsafe(HTMLString html);
-};
-
-[Exposed=Window]
-interface DOMParser {
-  constructor();
-  [NewObject] Document parseFromString(HTMLString str, SupportedType type);
-};
-
-partial interface Document {
-  static Document parseHTMLUnsafe(HTMLString html);
 };
 </pre>
 


### PR DESCRIPTION
Certain IDL was in the DOM Parser section when it should be in HTML


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/477.html" title="Last updated on Mar 13, 2024, 4:48 PM UTC (4ec37ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/477/1eee73a...lukewarlow:4ec37ec.html" title="Last updated on Mar 13, 2024, 4:48 PM UTC (4ec37ec)">Diff</a>