### PR TITLE
Update handling of timer functions

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1248,14 +1248,14 @@ partial interface mixin WindowOrWorkerGlobalScope {
 };
 </pre>
 
-To the [[HTML5#timer-initialisation-steps|timer initialization steps algorithm]],
-change step 8.3.2 as follows:
-
-1.  Perform <del>HostEnsureCanCompileStrings</del><ins>EnsureCSPDoesNotBlockStringCompilation</ins>(<var>realm</var>, « », <var>handler</var>,<del> false</del><ins>, <var>handler</var>, ~timer~, « », <var>handler</var></ins>). If this throws an exception, catch it, report the exception, and abort these steps.
-
 Note: This makes sure that a {{TrustedScript}} is passed to timer
 functions in place of a string when Trusted Types are enforced, but
 also unconditionally accepts any {{Function}} object.
+
+To the [[HTML5#timer-initialisation-steps|timer initialization steps algorithm]],
+change step 8.4.3 as follows:
+
+1.  Perform <del>HostEnsureCanCompileStrings</del><ins>EnsureCSPDoesNotBlockStringCompilation</ins>(<var>realm</var>, « », <var>handler</var>,<del> false</del><ins>, <var>handler</var>, ~timer~, « », <var>handler</var></ins>). If this throws an exception, catch it, report the exception, and abort these steps.
 
 ### Enforcement in event handler content attributes ### {#enforcement-in-event-handler-content-attributes}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1249,17 +1249,9 @@ partial interface mixin WindowOrWorkerGlobalScope {
 </pre>
 
 To the [[HTML5#timer-initialisation-steps|timer initialization steps algorithm]],
-add this step between 7.1 and 7.2:
+change step 8.3.2 as follows:
 
-1.  If the first operation argument is not a {{Function}}, set the first operation argument to the result of executing
-    the [$Get Trusted Type compliant string$] algorithm, with
-    *   |global| set to the [=this=] value's [=relevant global object=].
-    *   |input| set to the first method argument, and
-    *   |expectedType| set to {{TrustedScript}}.
-    *   |sink| set to `Window setInterval` if <var ignore>repeat</var> is true, `Window setTimeout` otherwise.
-    *   |sinkGroup| set to `'script'`.
-
-        Note: This matches the logic that the extended attribute would apply.
+1.  Perform HostEnsureCanCompileStrings(<var>realm</var>, « », <var>handler</var>,<del> false</del><ins>, <var>handler</var>, ~timer~, « », <var>handler</var></ins>). If this throws an exception, catch it, report the exception, and abort these steps.
 
 Note: This makes sure that a {{TrustedScript}} is passed to timer
 functions in place of a string when Trusted Types are enforced, but
@@ -1668,32 +1660,35 @@ The Trusted Types portion of this algorithm uses |calleeRealm| and its CSP setti
 Given a [[ECMA-262#realm|realm]] (|calleeRealm|), a list of strings (|parameterStrings|), a string (|bodyString|), <ins> a string (|source|), an enum (|compilationType|), a list of ECMAScript language values (|parameterArgs|), and an ECMAScript language value (|bodyArg|), this algorithm returns normally if compilation is allowed, and
 throws an "`EvalError`" if not:
 
-1.  <ins>Let |compilationSink| be `"Function"` if |compilationType| is `*FUNCTION*`, otherwise `"Eval"`.</ins>
-1.  <ins>Let |isTrusted| be `true`.</ins>
-1.  <ins>If |bodyArg| is not a {{TrustedScript}} object, set |isTrusted| to `false`.</ins>
-1.  <ins>If |isTrusted| is `true` then:
-    1. <ins>If |bodyString| is not equal to |bodyArg|'s [=TrustedScript/[[Data]]=] internal slot, set |isTrusted| to `false`.</ins>
-1.  <ins>If |isTrusted| is `true`, then:</ins>
-    1. <ins> For each |arg| in |parameterArgs|:</ins>
-        1. <ins>Let |index| be the index of |arg| in |parameterArgs|.</ins>
-        1. <ins>If |arg| is not a {{TrustedScript}} object, set |isTrusted| to `false`.</ins>
-        1. <ins>If |isTrusted| is `true`, then:</ins>
-            1. <ins>if |parameterStrings|[|index|] is not equal to |arg|'s [=TrustedScript/[[Data]]=] internal slot, set |isTrusted| to `false`.</ins>
-1.  <ins>If |isTrusted| is `true`, let |sourceToValidate| be a new instance of
-    the {{TrustedScript}} interface, with its [=TrustedScript/[[Data]]=] internal slot value
-    set to |source|. Otherwise, let |sourceToValidate| be |source|.</ins>
+1.  <ins>If |compilationType| is `*TIMER*`, then:</ins>
+    1.  <ins>Let |sourceString| be |source|.</ins>
+1.  <ins>Else:</ins>
+    1.  <ins>Let |compilationSink| be `"Function"` if |compilationType| is `*FUNCTION*`, otherwise `"Eval"`.</ins>
+    1.  <ins>Let |isTrusted| be `true`.</ins>
+    1.  <ins>If |bodyArg| is not a {{TrustedScript}} object, set |isTrusted| to `false`.</ins>
+    1.  <ins>If |isTrusted| is `true` then:
+        1. <ins>If |bodyString| is not equal to |bodyArg|'s [=TrustedScript/[[Data]]=] internal slot, set |isTrusted| to `false`.</ins>
+    1.  <ins>If |isTrusted| is `true`, then:</ins>
+        1. <ins> For each |arg| in |parameterArgs|:</ins>
+            1. <ins>Let |index| be the index of |arg| in |parameterArgs|.</ins>
+            1. <ins>If |arg| is not a {{TrustedScript}} object, set |isTrusted| to `false`.</ins>
+            1. <ins>If |isTrusted| is `true`, then:</ins>
+                1. <ins>if |parameterStrings|[|index|] is not equal to |arg|'s [=TrustedScript/[[Data]]=] internal slot, set |isTrusted| to `false`.</ins>
+    1.  <ins>If |isTrusted| is `true`, let |sourceToValidate| be a new instance of
+        the {{TrustedScript}} interface, with its [=TrustedScript/[[Data]]=] internal slot value
+        set to |source|. Otherwise, let |sourceToValidate| be |source|.</ins>
 
-1. <ins>Let |sourceString| be the result of executing the
-    [$Get Trusted Type compliant string$] algorithm, with:
-    *   |calleeRealm| as |global|,
-    *   |sourceToValidate| as |input|,
-    *   |compilationSink| as |sink|,
-    *   `'script'` as |sinkGroup|,
-    *   {{TrustedScript}} as |expectedType|.</ins>
+    1. <ins>Let |sourceString| be the result of executing the
+        [$Get Trusted Type compliant string$] algorithm, with:
+        *   |calleeRealm| as |global|,
+        *   |sourceToValidate| as |input|,
+        *   |compilationSink| as |sink|,
+        *   `'script'` as |sinkGroup|,
+        *   {{TrustedScript}} as |expectedType|.</ins>
 
-1.  <ins>If the algorithm throws an error, throw an {{EvalError}}.</ins>
+    1.  <ins>If the algorithm throws an error, throw an {{EvalError}}.</ins>
 
-1.  <ins>If |sourceString| is not equal to |source|, throw an {{EvalError}}.</ins>
+    1.  <ins>If |sourceString| is not equal to |source|, throw an {{EvalError}}.</ins>
 
 1.  Let |global| be a |calleeRealm|'s [=realm/global object=].
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1251,7 +1251,7 @@ partial interface mixin WindowOrWorkerGlobalScope {
 To the [[HTML5#timer-initialisation-steps|timer initialization steps algorithm]],
 change step 8.3.2 as follows:
 
-1.  Perform HostEnsureCanCompileStrings(<var>realm</var>, « », <var>handler</var>,<del> false</del><ins>, <var>handler</var>, ~timer~, « », <var>handler</var></ins>). If this throws an exception, catch it, report the exception, and abort these steps.
+1.  Perform <del>HostEnsureCanCompileStrings</del><ins>EnsureCSPDoesNotBlockStringCompilation</ins>(<var>realm</var>, « », <var>handler</var>,<del> false</del><ins>, <var>handler</var>, ~timer~, « », <var>handler</var></ins>). If this throws an exception, catch it, report the exception, and abort these steps.
 
 Note: This makes sure that a {{TrustedScript}} is passed to timer
 functions in place of a string when Trusted Types are enforced, but


### PR DESCRIPTION
Fixes #480 

This effectively follows the Chromium implementation, we use the StringContext attribute to do the enforcement for setTimeout and setInterval and then update the `HostEnsureCanCompileStrings` call (which now actually calls the CSP function directly) accordingly.

We then update `EnsureCSPDoesNotBlockStringCompilation` to only do TT validation for eval and Function, not timers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/481.html" title="Last updated on Mar 26, 2024, 4:45 PM UTC (2c0de9f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/481/1eee73a...lukewarlow:2c0de9f.html" title="Last updated on Mar 26, 2024, 4:45 PM UTC (2c0de9f)">Diff</a>