### PR TITLE
Update IDL for script enforcement

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1174,7 +1174,7 @@ The {{HTMLScriptElement/innerText}} setter steps are:
 1.  Let |value| be the result of calling [$Get Trusted Type compliant string$] with
     {{TrustedScript}}, [=this=]'s [=relevant global object=], the given value, `HTMLScriptElement innerText`, and
     `script`.
-1.  Set [=script text=] value to |value|.
+1.  Set [=this=]'s [=script text=] value to |value|.
 1.  Run [=set the inner text steps=] with [=this=] and |value|.
 
 The {{HTMLScriptElement/innerText}} getter steps are:
@@ -1189,7 +1189,7 @@ empty string instead, and then do as described below:
 1.  Let |value| be the result of calling [$Get Trusted Type compliant string$] with
     {{TrustedScript}}, [=this=]'s [=relevant global object=], the given value, `HTMLScriptElement textContent`, and
     `script`.
-1.  Set [=script text=] value to |value|.
+1.  Set [=this=]'s [=script text=] value to |value|.
 1.  Run [=set text content=] with [=this=] and |value|.
 
 The {{HTMLScriptElement/textContent}} getter steps are:
@@ -1203,8 +1203,8 @@ Update the {{HTMLScriptElement/text}} setter steps algorithm as follows.
 1.  <ins>Let |value| be the result of calling [$Get Trusted Type compliant string$] with
     {{TrustedScript}}, [=this=]'s [=relevant global object=], the given value, `HTMLScriptElement text`, and
     `script`.</ins>
-1.  <ins>Set [=script text=] value to the given value.</ins>
-1.  [=String replace all=] with the given value within this <code>script</code> element.
+1.  <ins>Set [=this=]'s [=script text=] value to the given value.</ins>
+1.  [=String replace all=] with the given value within this.
 
 
 #### The {{HTMLScriptElement/src}} IDL attribute #### {#the-src-idl-attribute}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -122,6 +122,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     type: dfn; text: prepare the script element; url: prepare-the-script-element
     type: dfn; text: get the text steps; url: get-the-text-steps
     type: dfn; text: set the inner text steps; url: set-the-inner-text-steps
+    type: dfn; text: src; url: attr-script-src
 spec:DOM; urlPrefix: https://dom.spec.whatwg.org/
     type: dfn; text: get text content; url: get-text-content
     type: dfn; text: set text content; url: set-text-content
@@ -1144,16 +1145,16 @@ type policy factory]].
 
 This document modifies how {{HTMLScriptElement}} [=child text content=] can be set to allow applications to control dynamically created scripts. It does so by
 adding the {{HTMLElement/innerText}} and {{Node/textContent}} attributes directly on {{HTMLScriptElement}}. The behavior of the attributes remains the same
-as in their original counterparts, apart from additional behavior triggered by the {{StringContext}} extended attribute presence.
+as in their original counterparts, apart from the additional behavior of calling [$Get Trusted Type compliant string$].
 
 Note: Using these IDL attributes is the recommended way of dynamically setting the URL or a text of a script. Manipulating attribute nodes or text nodes directly will call a default policy on the final value when the script is prepared.
 
 <pre class="idl exclude">
 partial interface HTMLScriptElement {
- [CEReactions] attribute [LegacyNullToEmptyString] ScriptString innerText;
+ [CEReactions] attribute ([LegacyNullToEmptyString] DOMString or TrustedScript) innerText;
  [CEReactions] attribute (DOMString or TrustedScript)? textContent;
- [CEReactions] attribute ScriptURLString src;
- [CEReactions] attribute ScriptString text;
+ [CEReactions] attribute (USVString or TrustedScriptURL) src;
+ [CEReactions] attribute (DOMString or TrustedScript) text;
 };
 </pre>
 
@@ -1163,13 +1164,16 @@ This document modifies {{HTMLScriptElement}}s. Each script has:
 
 : an associated string <dfn export for="HTMLScriptElement">script text</dfn>.
 ::  A string, containing the body of the script to execute that was set
-    through a {{StringContext}} compliant sink. Equivalent to script's
+    through a compliant sink. Equivalent to script's
     [=child text content=]. Initially an empty string.
 
 #### The {{HTMLScriptElement/innerText}} IDL attribute #### {#the-innerText-idl-attribute}
 
 The {{HTMLScriptElement/innerText}} setter steps are:
 
+1.  Let |value| be the result of calling [$Get Trusted Type compliant string$] with
+    {{TrustedScript}}, [=this=]'s [=relevant global object=], the given value, `HTMLScriptElement innerText`, and
+    `script`.
 1.  Set [=script text=] value to |value|.
 1.  Run [=set the inner text steps=] with [=this=] and |value|.
 
@@ -1183,7 +1187,7 @@ The {{HTMLScriptElement/textContent}} setter steps are to, if the given value is
 empty string instead, and then do as described below:
 
 1.  Let |value| be the result of calling [$Get Trusted Type compliant string$] with
-    {{TrustedScript}}, [=this=]'s [=relevant global object=], the given value, `HTMLScriptElement textContent`,
+    {{TrustedScript}}, [=this=]'s [=relevant global object=], the given value, `HTMLScriptElement textContent`, and
     `script`.
 1.  Set [=script text=] value to |value|.
 1.  Run [=set text content=] with [=this=] and |value|.
@@ -1196,8 +1200,21 @@ The {{HTMLScriptElement/textContent}} getter steps are:
 
 Update the {{HTMLScriptElement/text}} setter steps algorithm as follows.
 
+1.  <ins>Let |value| be the result of calling [$Get Trusted Type compliant string$] with
+    {{TrustedScript}}, [=this=]'s [=relevant global object=], the given value, `HTMLScriptElement text`, and
+    `script`.</ins>
 1.  <ins>Set [=script text=] value to the given value.</ins>
 1.  [=String replace all=] with the given value within this <code>script</code> element.
+
+
+#### The {{HTMLScriptElement/src}} IDL attribute #### {#the-src-idl-attribute}
+
+The {{HTMLScriptElement/src}} setter steps are:
+
+1.  <ins>Let |value| be the result of calling [$Get Trusted Type compliant string$] with
+    {{TrustedScriptURL}}, [=this=]'s [=relevant global object=], the given value, `HTMLScriptElement src`, and
+    `script`.</ins>
+1.  <ins>Set [=this=]'s [=src=] content attribute to |value|.</ins>
 
 #### Slot value verification #### {#slot-value-verification}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1204,7 +1204,7 @@ Update the {{HTMLScriptElement/text}} setter steps algorithm as follows.
     {{TrustedScript}}, [=this=]'s [=relevant global object=], the given value, `HTMLScriptElement text`, and
     `script`.</ins>
 1.  <ins>Set [=this=]'s [=script text=] value to the given value.</ins>
-1.  [=String replace all=] with the given value within this.
+1.  [=String replace all=] with the given value within [=this=].
 
 
 #### The {{HTMLScriptElement/src}} IDL attribute #### {#the-src-idl-attribute}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -120,6 +120,11 @@ spec:ECMA-262; urlPrefix: https://tc39.github.io/ecma262/
     type:dfn; text:current realm record; url: current-realm
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     type: dfn; text: prepare the script element; url: prepare-the-script-element
+    type: dfn; text: get the text steps; url: get-the-text-steps
+    type: dfn; text: set the inner text steps; url: set-the-inner-text-steps
+spec:DOM; urlPrefix: https://dom.spec.whatwg.org/
+    type: dfn; text: get text content; url: get-text-content
+    type: dfn; text: set text content; url: set-text-content
 </pre>
 
 <pre class="link-defaults">
@@ -1137,6 +1142,21 @@ type policy factory]].
 
 ### Enforcement for scripts ### {#enforcement-in-scripts}
 
+This document modifies how {{HTMLScriptElement}} [=child text content=] can be set to allow applications to control dynamically created scripts. It does so by
+adding the {{HTMLElement/innerText}} and {{Node/textContent}} attributes directly on {{HTMLScriptElement}}. The behavior of the attributes remains the same
+as in their original counterparts, apart from additional behavior triggered by the {{StringContext}} extended attribute presence.
+
+Note: Using these IDL attributes is the recommended way of dynamically setting the URL or a text of a script. Manipulating attribute nodes or text nodes directly will call a default policy on the final value when the script is prepared.
+
+<pre class="idl exclude">
+partial interface HTMLScriptElement {
+ [CEReactions] attribute [LegacyNullToEmptyString] ScriptString innerText;
+ [CEReactions] attribute (DOMString or TrustedScript)? textContent;
+ [CEReactions] attribute ScriptURLString src;
+ [CEReactions] attribute ScriptString text;
+};
+</pre>
+
 #### Slots with trusted values #### {#slots-with-trusted-values}
 
 This document modifies {{HTMLScriptElement}}s. Each script has:
@@ -1146,27 +1166,38 @@ This document modifies {{HTMLScriptElement}}s. Each script has:
     through a {{StringContext}} compliant sink. Equivalent to script's
     [=child text content=]. Initially an empty string.
 
-#### Setting slot values #### {#setting-slot-values}
+#### The {{HTMLScriptElement/innerText}} IDL attribute #### {#the-innerText-idl-attribute}
 
-This document modifies how {{HTMLScriptElement}} [=child text content=] can be set to allow applications to control dynamically created scripts. It does so by
-adding the {{HTMLElement/innerText}} and {{Node/textContent}} attributes directly on {{HTMLScriptElement}}. The behavior of the attributes remains the same
-as in their original counterparts, apart from additional behavior triggered by the {{StringContext}} extended attribute presence.
+The {{HTMLScriptElement/innerText}} setter steps are:
 
-Note: Using these IDL attributes is the recommended way of dynamically setting URL or a text of a script. Manipulating attribute nodes or text nodes directly will call a default policy on the final value when the script is prepared.
+1.  Set [=script text=] value to |value|.
+1.  Run [=set the inner text steps=] with [=this=] and |value|.
 
-<pre class="idl exclude">
-partial interface HTMLScriptElement {
- [CEReactions] attribute [LegacyNullToEmptyString] ScriptString innerText;
- [CEReactions] attribute ScriptString? textContent;
- [CEReactions] attribute ScriptURLString src;
- [CEReactions] attribute ScriptString text;
-};
-</pre>
+The {{HTMLScriptElement/innerText}} getter steps are:
 
-On setting the {{HTMLElement/innerText}}, {{Node/textContent}} and {{HTMLScriptElement/text}} IDL attributes execute the following algorithm:
+1.  Return the result of running [=get the text steps=] with [=this=].
 
-1. Set [=script text=] value to the stringified attribute value.
-1. Perform the usual attribute setter steps.
+#### The {{HTMLScriptElement/textContent}} IDL attribute #### {#the-textContent-idl-attribute}
+
+The {{HTMLScriptElement/textContent}} setter steps are to, if the given value is null, act as if it was the
+empty string instead, and then do as described below:
+
+1.  Let |value| be the result of calling [$Get Trusted Type compliant string$] with
+    {{TrustedScript}}, [=this=]'s [=relevant global object=], the given value, `HTMLScriptElement textContent`,
+    `script`.
+1.  Set [=script text=] value to |value|.
+1.  Run [=set text content=] with [=this=] and |value|.
+
+The {{HTMLScriptElement/textContent}} getter steps are:
+
+1.  Return the result of running [=get text content=] with [=this=].
+
+#### The {{HTMLScriptElement/text}} IDL attribute #### {#the-text-idl-attribute}
+
+Update the {{HTMLScriptElement/text}} setter steps algorithm as follows.
+
+1.  <ins>Set [=script text=] value to the given value.</ins>
+1.  [=String replace all=] with the given value within this <code>script</code> element.
 
 #### Slot value verification #### {#slot-value-verification}
 


### PR DESCRIPTION
- Node/textContent, and Element/innerText are both now shadowed on HTMLScriptElement.

~HTMLScriptElement/textContent uses a union type rather than [StringContext] because it uses a nullable type.~

All of the properties are using union types as that seems to be the direction the spec is going to go in. But I can revert that commit and go back to using the extended attribute.

This PR is part of 1 of addressing #437 it specifically doesn't address https://github.com/w3c/trusted-types/issues/483 or https://github.com/w3c/trusted-types/issues/252


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/484.html" title="Last updated on Apr 22, 2024, 4:02 PM UTC (80b9076)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/484/74e413e...lukewarlow:80b9076.html" title="Last updated on Apr 22, 2024, 4:02 PM UTC (80b9076)">Diff</a>