### PR TITLE
Remove changes upstreamed to DOM Parsing

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1415,25 +1415,6 @@ On setting {{SVGAnimatedString/baseVal}}, the following steps are run:
 
 Note: SVG does not have a complete script processing model <a href="https://github.com/w3c/svgwg/issues/196">yet</a>. Trusted Types assumes that the attribute and text body modification protections behave similarly to ones for HTML scripts outlined in [[#enforcement-in-scripts]].
 
-## Integration with DOM Parsing ## {#integration-with-dom-parsing}
-
-This document modifies the following interfaces defined by [[DOM-Parsing]]:
-
-<pre class="idl exclude">
-partial interface Element {
-  [CEReactions, LegacyNullToEmptyString] attribute HTMLString outerHTML;
-  [CEReactions] undefined insertAdjacentHTML(DOMString position, HTMLString text);
-};
-
-partial interface mixin InnerHTML { // specified in a draft version at https://w3c.github.io/DOM-Parsing/#the-innerhtml-mixin
-  [CEReactions] attribute [LegacyNullToEmptyString] HTMLString innerHTML;
-};
-
-partial interface Range {
-  [CEReactions, NewObject] DocumentFragment createContextualFragment(HTMLString fragment);
-};
-</pre>
-
 ## Integration with execCommand ## {#integration-with-exec-command}
 
 This document modifies the following interfaces defined by the unofficial <a href="https://w3c.github.io/editing/docs/execCommand/">execCommand</a> document:


### PR DESCRIPTION
See https://github.com/w3c/DOM-Parsing/pull/78


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/489.html" title="Last updated on Mar 25, 2024, 11:30 AM UTC (9b54fbf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/489/fc82918...lukewarlow:9b54fbf.html" title="Last updated on Mar 25, 2024, 11:30 AM UTC (9b54fbf)">Diff</a>