### PR TITLE
Add missing HostEnsureCanCompileStrings monkeypatch

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1281,6 +1281,15 @@ Note: This also applies to events in [[SVG2#EventAttributes]].
   </pre>
 </div>
 
+### HostEnsureCanCompileStrings ### {#host-ensure-can-compile-strings}
+
+JavaScript contains an <span>implementation-defined</span> <a href="https://tc39.es/ecma262/#sec-hostensurecancompilestrings">HostEnsureCanCompileStrings</a>(<var>realm</var>, <ins><var>parameterStrings</var>,
+<var>bodyString</var>, <var>codeString</var>, <var>compilationType</var>, <var>parameterArgs</var>, <var>bodyArg</var></ins>)
+abstract operation. User agents must use the following implementation:
+
+1. Perform ? [[CSP3#can-compile-strings|EnsureCSPDoesNotBlockStringCompilation]](<var>realm</var>, <ins><var>parameterStrings</var>,
+    <var>bodyString</var>, <var>codeString</var>, <var>compilationType</var>, <var>parameterArgs</var>, <var>bodyArg</var></ins>).
+
 ### Validate the string in context ### {#html-validate-the-string-in-context}
 
 This specification defines the <a>validate the string in context</a> algorithm in [[html#integration-with-idl]].


### PR DESCRIPTION
This won't be needed for long as this will be upstreamed to HTML very soon, but for the sake of completeness here's the missing override of `HostEnsureCanCompileStrings` HTML definition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/490.html" title="Last updated on Mar 26, 2024, 4:23 PM UTC (cb341ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/490/b38b323...lukewarlow:cb341ce.html" title="Last updated on Mar 26, 2024, 4:23 PM UTC (cb341ce)">Diff</a>