### PR TITLE
Fix type issue between get tt compliant string and validate string in context

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1022,19 +1022,21 @@ This algorithm will return a string that can be used with an
 It will ensure that the Trusted Type [=enforcement=] rules were respected.
 
 Given a {{TrustedType}} type (|expectedType|), a [=realm/global object=] (|global|),
-{{TrustedType}} or a string (|input|), a string (|sink|) and a string (|sinkGroup|), run these steps:
+an [=ECMAScript language value=] (|input|), a string (|sink|) and a string (|sinkGroup|), run these steps:
 
-1.  If |input| has type |expectedType|, return stringified
-    |input| and abort these steps.
+1.  Let |stringifiedInput| be the result of executing [$ToString$] on |input|.
+1.  If the algorithm threw an error, rethrow the error and abort the following steps.
+1.  If |input| has type |expectedType|, return |stringifiedInput| and abort these steps.
 1.  Let |requireTrustedTypes| be the result of executing [$Does sink type require trusted types?$] algorithm,
     passing |global|, and |sinkGroup|.
-1.  If |requireTrustedTypes| is `false`, return stringified |input| and abort these steps.
-1.  Let |convertedInput| be the result of executing [$Process value with a default policy$] with the same arguments as this algorithm.
+1.  If |requireTrustedTypes| is `false`, return |stringifiedInput| and abort these steps.
+1.  Let |convertedInput| be the result of executing [$Process value with a default policy$] with |expectedType|,
+    |global|, |stringifiedInput|, |sink|, and |sinkGroup| as arguments.
 1.  If the algorithm threw an error, rethrow the error and abort the following steps.
 1.  If |convertedInput| is `null` or `undefined`, execute the following steps:
     1.  Let |disposition| be the result of executing [$Should sink type mismatch violation be blocked by Content Security Policy?$] algorithm,
-        passing |global|, stringified |input| as |source|, |sinkGroup| and |sink|.
-    1.  If |disposition| is `“Allowed”`, return stringified |input| and abort further steps.
+        passing |global|, |stringifiedInput| as |source|, |sinkGroup| and |sink|.
+    1.  If |disposition| is `“Allowed”`, return |stringifiedInput| and abort further steps.
 
         Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.
     1. Throw a TypeError and abort further steps.


### PR DESCRIPTION
Get TT compliant string now takes any value, rather than just string or a TT. It then correctly stringifies this value.

Fixes #488


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/497.html" title="Last updated on Apr 4, 2024, 1:03 PM UTC (c887020)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/497/39cc82e...lukewarlow:c887020.html" title="Last updated on Apr 4, 2024, 1:03 PM UTC (c887020)">Diff</a>