### PR TITLE
Remove links to merged upstream PRs

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1306,14 +1306,6 @@ When <a>validate the string in context</a> is invoked, with |platformObject|, |v
     1. If an exception was thrown, rethrow exception and abort further steps.
  1. Return |value|.
 
-## Integration with Service Workers ## {#sw-integration}
-
-Note: See [https://github.com/w3c/ServiceWorker/pull/1709](https://github.com/w3c/ServiceWorker/pull/1709) which upstreams this integration.
-
-## Integration with execCommand ## {#integration-with-exec-command}
-
-Note: See [https://github.com/w3c/editing/pull/460](https://github.com/w3c/editing/pull/460) which upstreams this integration.
-
 ## Integration with DOM ## {#integration-with-dom}
 
 Note: See [https://github.com/whatwg/dom/pull/1258](https://github.com/whatwg/dom/pull/1258) and [https://github.com/whatwg/dom/pull/1268](https://github.com/whatwg/dom/pull/1268) which upstream this integration.


### PR DESCRIPTION
Service worker and execCommand have been merged upstream.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/515.html" title="Last updated on May 14, 2024, 3:04 PM UTC (5336b1f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/515/54cf168...lukewarlow:5336b1f.html" title="Last updated on May 14, 2024, 3:04 PM UTC (5336b1f)">Diff</a>