### PR TITLE
Remove HostEnsureCanCompileStrings and HostGetCodeForEval

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1248,23 +1248,6 @@ The first few steps of the [=prepare the script element=] algorithm are modified
   <li>...
   </ol>
 
-### HostEnsureCanCompileStrings ### {#host-ensure-can-compile-strings}
-
-JavaScript contains an <span>implementation-defined</span> <a href="https://tc39.es/ecma262/#sec-hostensurecancompilestrings">HostEnsureCanCompileStrings</a>(<var>realm</var>, <ins><var>parameterStrings</var>,
-<var>bodyString</var>, <var>compilationType</var>, <var>parameterArgs</var>, <var>bodyArg</var></ins>)
-abstract operation. User agents must use the following implementation:
-
-1. Perform ? [[CSP3#can-compile-strings|EnsureCSPDoesNotBlockStringCompilation]](<var>realm</var>, <ins><var>parameterStrings</var>,
-    <var>bodyString</var>, <var>compilationType</var>, <var>parameterArgs</var>, <var>bodyArg</var></ins>).
-
-### HostGetCodeForEval ### {#host-get-code-for-eval}
-
-JavaScript contains an <span>implementation-defined</span> <a href="https://tc39.es/ecma262/#sec-hostgetcodeforeval">HostGetCodeForEval</a>(<var>argument</var>)
-abstract operation. User agents must use the following implementation:
-
-1.  If |argument| is a {{TrustedScript}} object, return the value of its associated [=TrustedScript/data=].
-1.  Return ~unknown~.
-
 ## Integration with DOM ## {#integration-with-dom}
 
 Note: See [https://github.com/whatwg/dom/pull/1258](https://github.com/whatwg/dom/pull/1258) and [https://github.com/whatwg/dom/pull/1268](https://github.com/whatwg/dom/pull/1268) which upstream this integration.


### PR DESCRIPTION
These have been upstreamed to the HTML spec

Draft until https://github.com/whatwg/html/pull/10204 is merged


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/523.html" title="Last updated on Jun 12, 2024, 1:16 PM UTC (f4c4bd7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/523/92390d1...lukewarlow:f4c4bd7.html" title="Last updated on Jun 12, 2024, 1:16 PM UTC (f4c4bd7)">Diff</a>