### PR TITLE
Handle null policyValue in Create a Trusted Type

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -981,6 +981,7 @@ a string |value| and a list |arguments|, execute the following steps:
 1.  Let |policyValue| be the result of executing [$Get Trusted Type policy value$] with the same arguments as this algorithm and additionally true as |throwIfMissing|.
 1.  If the algorithm threw an error, rethrow the error and abort the following steps.
 1.  Let |dataString| be the result of stringifying |policyValue|.
+1.  If |policyValue| is null or undefined, set |dataString| to the empty string.
 1.  Return a new instance of an interface with a type
     name |trustedTypeName|, with its associated data value set to |dataString|.
 


### PR DESCRIPTION
Fixes #469


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/527.html" title="Last updated on Jun 18, 2024, 1:41 PM UTC (3e9fe32)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/527/e776fc6...lukewarlow:3e9fe32.html" title="Last updated on Jun 18, 2024, 1:41 PM UTC (3e9fe32)">Diff</a>