### PR TITLE
Strip "function anonymous" prefixes from Function samples

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1426,6 +1426,12 @@ returns `"Blocked"` if the [=injection sink=] requires a [=Trusted Type=], and
 `"Allowed"` otherwise.
 
 1.  Let |result| be `"Allowed"`.
+1.  Let |sample| be |source|.
+1.  If |sink| is `"Function"`, then:
+    1. If |sample| starts with `"function anonymous"`, strip that from |sample|.
+    1. Otherwise if |sample| starts with `"async function anonymous"`, strip that from |sample|.
+    1. Otherwise if |sample| starts with `"function* anonymous"`, strip that from |sample|.
+    1. Otherwise if |sample| starts with `"async function* anonymous"`, strip that from |sample|.
 1.  For each |policy| in |global|'s <a>CSP list</a>:
     1.  If |policy|'s <a>directive set</a> does not contain a <a>directive</a>
         whose [=directive/name=] is `"require-trusted-types-for"`, skip to the next |policy|.
@@ -1437,8 +1443,8 @@ returns `"Blocked"` if the [=injection sink=] requires a [=Trusted Type=], and
         [[CSP#create-violation-for-global|Create a violation object for global, policy, and directive]]
         on |global|, |policy| and `"require-trusted-types-for"`
     1. Set |violation|'s [=violation/resource=] to `"trusted-types-sink"`.
-    1. Let |trimmedSource| be the substring of |source|, containing its first 40 characters.
-    1. Set |violation|'s [=violation/sample=] to be the result of [=concatenating=] the list &laquo; |sink|, |trimmedSource| &laquo; using `"|"` as a |separator|.
+    1. Let |trimmedSample| be the substring of |sample|, containing its first 40 characters.
+    1. Set |violation|'s [=violation/sample=] to be the result of [=concatenating=] the list &laquo; |sink|, |trimmedSample| &laquo; using `"|"` as a separator.
     1.  Execute [[CSP#report-violation|Report a violation]] on |violation|.
     1.  If |policy|'s [=policy/disposition=] is `"enforce"`, then set |result| to
         `"Blocked"`.


### PR DESCRIPTION
Fixes #491 

cc @koto @otherdaniel


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/539.html" title="Last updated on Jul 29, 2024, 9:41 AM UTC (3556e6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/539/cf78f7e...lukewarlow:3556e6a.html" title="Last updated on Jul 29, 2024, 9:41 AM UTC (3556e6a)">Diff</a>