### PR TITLE
Remove CSP dynamic code compilation block

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -748,9 +748,9 @@ anElement.innerHTML = trustedTypes.emptyHTML; // no need to create a policy
 : <dfn>emptyScript</dfn>
 :: is a {{TrustedScript}} object with its [=TrustedScript/data=] value set to an empty string.
 
-Note: This object can be used to detect if the runtime environment has [[#csp-eval]]. While native Trusted Types implementation can
-support `eval(TrustedScript)`, it is impossible for a polyfill to  emulate that, as
-eval(TrustedScript) will return its input without unwrapping and evaluating the code.
+Note: This object can be used to detect if the runtime environment has support for dynamic code compilation.
+While native Trusted Types implementation can support `eval(TrustedScript)`, it is impossible for a polyfill to
+emulate that, as eval(TrustedScript) will return its input without unwrapping and evaluating the code.
 
 <div class="example" id="empty-script-example">
 <xmp highlight="js">
@@ -1482,10 +1482,6 @@ strings (|createdPolicyNames|), this algorithm returns `"Blocked"` if the
     1.  If |policy|'s [=policy/disposition=] is `"enforce"`, then set |result| to
         `"Blocked"`.
 1. Return |result|.
-
-### Support for dynamic code compilation ### {#csp-eval}
-
-Note: See [https://github.com/w3c/webappsec-csp/pull/659](https://github.com/w3c/webappsec-csp/pull/659) which upstreams this integration.
 
 # Security Considerations # {#security-considerations}
 


### PR DESCRIPTION
This has been upstreamed to the CSP spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/544.html" title="Last updated on Sep 9, 2024, 3:03 PM UTC (60f9094)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/544/cf78f7e...lukewarlow:60f9094.html" title="Last updated on Sep 9, 2024, 3:03 PM UTC (60f9094)">Diff</a>