### PR TITLE
Fix column indices for callers of "Get Trusted Type data for attribute"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -722,7 +722,7 @@ Its value is initially « ».
         * |interface| as |element|
         * |attribute|
         * |attrNs|
-    1. If |attributeData| is not null, then set |expectedType| to the value of the third member of |attributeData|.
+    1. If |attributeData| is not null, then set |expectedType| to the value of the fourth member of |attributeData|.
     1. Return |expectedType|.
 
     <div class="example" id="get-attribute-type-example">
@@ -1092,8 +1092,8 @@ To <dfn abstract-op export>get Trusted Types-compliant attribute value</dfn> on 
     1. If |newValue| is a string, return |newValue|.
     1. <a>Assert</a>: |newValue| is {{TrustedHTML}} or {{TrustedScript}} or {{TrustedScriptURL}}.
     1. Return |value|'s associated data.
-1. Let |expectedType| be the value of the third member of |attributeData|.
-1. Let |sink| be the value of the fourth member of |attributeData|.
+1. Let |expectedType| be the value of the fourth member of |attributeData|.
+1. Let |sink| be the value of the fifth member of |attributeData|.
 1. Return the result of executing [$Get Trusted Type compliant string$] with the following arguments:
      * |expectedType|
      * |newValue| as |input|


### PR DESCRIPTION
Closes https://github.com/w3c/trusted-types/issues/551


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/trusted-types/pull/555.html" title="Last updated on Oct 22, 2024, 10:51 PM UTC (d06eddd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/555/3b74745...fred-wang:d06eddd.html" title="Last updated on Oct 22, 2024, 10:51 PM UTC (d06eddd)">Diff</a>