### PR TITLE
Clarify that expectedType is set to the interface's name of TrustedType values

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -680,7 +680,7 @@ Its value is initially « ».
     1. Let |interface| be the [=element interface=] for |localName| and |elementNs|.
     1. Let |expectedType| be null.
     1. Find the row in the following table, where the first column is "*" or |interface|'s name, and |property| is in the second column.
-        If a matching row is found, set |expectedType| to the value of the third column.
+        If a matching row is found, set |expectedType| to the interface's name of the value of the third column.
 
         <table>
           <thead>
@@ -722,7 +722,7 @@ Its value is initially « ».
         * |interface| as |element|
         * |attribute|
         * |attrNs|
-    1. If |attributeData| is not null, then set |expectedType| to the value of the fourth member of |attributeData|.
+    1. If |attributeData| is not null, then set |expectedType| to the interface's name of the value of the fourth member of |attributeData|.
     1. Return |expectedType|.
 
     <div class="example" id="get-attribute-type-example">


### PR DESCRIPTION
Closes https://github.com/w3c/trusted-types/issues/552


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/trusted-types/pull/556.html" title="Last updated on Oct 28, 2024, 1:17 PM UTC (899d576)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/556/3f3a848...fred-wang:899d576.html" title="Last updated on Oct 28, 2024, 1:17 PM UTC (899d576)">Diff</a>