### PR TITLE
Treat a null elementNs in getPropertyType/geAtributeType as the HTML …

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -676,7 +676,7 @@ Its value is initially « ».
     This function returns the result of the following algorithm:
 
     1. Set |localName| to |tagName| in [=ASCII lowercase=].
-    1. If |elementNs| is an empty string, set |elementNs| to [=HTML namespace=].
+    1. If |elementNs| is null or an empty string, set |elementNs| to [=HTML namespace=].
     1. Let |interface| be the [=element interface=] for |localName| and |elementNs|.
     1. Let |expectedType| be null.
     1. Find the row in the following table, where the first column is "*" or |interface|'s name, and |property| is in the second column.
@@ -714,7 +714,7 @@ Its value is initially « ».
 
     1. Set |localName| to |tagName| in [=ASCII lowercase=].
     1. Set |attribute| to |attribute| in [=ASCII lowercase=].
-    1. If |elementNs| is an empty string, set |elementNs| to [=HTML namespace=].
+    1. If |elementNs| is null or an empty string, set |elementNs| to [=HTML namespace=].
     1. If |attrNs| is an empty string, set |attrNs| to null.
     1. Let |interface| be the [=element interface=] for |localName| and |elementNs|.
     1. Let |expectedType| be null.


### PR DESCRIPTION
…namespace

This is the behavior that Chromium and WebKit currently implement, see https://phabricator.services.mozilla.com/D226547

Currently, it seems that the "interface for localName and elementNs" would fallback to `Element`, similarly to what happens with `document.createElementNS(null, "div")` for example.

Note that a null attrNs is already handled by the spec.

See also https://github.com/w3c/trusted-types/issues/553 for details.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/trusted-types/pull/557.html" title="Last updated on Oct 23, 2024, 8:57 AM UTC (c072d13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/557/3b74745...fred-wang:c072d13.html" title="Last updated on Oct 23, 2024, 8:57 AM UTC (c072d13)">Diff</a>