### PR TITLE
Fix dead link to "HTML imports" spec

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1517,7 +1517,7 @@ Some long-deprecated and rarely used platform features are not subject to Truste
 Types, and could potentially be used by malicious authors to overcome the
 restrictions:
 
-* <a href="https://w3c.github.io/webcomponents/spec/imports/">HTML imports</a>
+* <a href="https://wicg.github.io/webcomponents/spec/imports/">HTML imports</a>
 
 ## Script gadgets ## {#script-gadgets}
 


### PR DESCRIPTION
Closes https://github.com/w3c/trusted-types/issues/550


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/trusted-types/pull/558.html" title="Last updated on Oct 23, 2024, 9:09 AM UTC (c1bd260)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/558/3b74745...fred-wang:c1bd260.html" title="Last updated on Oct 23, 2024, 9:09 AM UTC (c1bd260)">Diff</a>