### PR TITLE
Sink group should be single-quoted only in CSP syntax.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1293,8 +1293,9 @@ ABNF:
 
 <pre>
 directive-name = "require-trusted-types-for"
-directive-value = <a>trusted-types-sink-group</a> *( <a href="https://w3c.github.io/webappsec-csp/#grammardef-required-ascii-whitespace">required-ascii-whitespace</a> <a>trusted-types-sink-group</a>)
-<dfn>trusted-types-sink-group</dfn> = "'script'"
+directive-value = <a>trusted-types-sink-group-keyword</a> *( <a href="https://w3c.github.io/webappsec-csp/#grammardef-required-ascii-whitespace">required-ascii-whitespace</a> <a>trusted-types-sink-group-keyword</a>)
+<dfn>trusted-types-sink-group-keyword</dfn> = "'" <a>trusted-types-sink-group</a> "'"
+<dfn>trusted-types-sink-group</dfn> = "script"
 </pre>
 
 <div class="example" id="require-tt-for-script-header">


### PR DESCRIPTION
Fixes #542


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/koto/trusted-types/pull/561.html" title="Last updated on Nov 6, 2024, 9:03 AM UTC (83953be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/561/324798d...koto:83953be.html" title="Last updated on Nov 6, 2024, 9:03 AM UTC (83953be)">Diff</a>