### PR TITLE
Remove link to https://github.com/whatwg/dom/pull/1258

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1273,7 +1273,7 @@ Issue: There's no proper definition for the processing of SVG script elements. H
 
 ## Integration with DOM ## {#integration-with-dom}
 
-Note: See [https://github.com/whatwg/dom/pull/1258](https://github.com/whatwg/dom/pull/1258) and [https://github.com/whatwg/dom/pull/1268](https://github.com/whatwg/dom/pull/1268) which upstream this integration.
+Note: See [https://github.com/whatwg/dom/pull/1268](https://github.com/whatwg/dom/pull/1268) which upstreams this integration.
 
 ## Integration with Content Security Policy ## {#integration-with-content-security-policy}
 


### PR DESCRIPTION
This was merged and reverted in
https://github.com/whatwg/dom/commit/809bfa24535b1d55d761d8add353e1c3fde05801

closes #537


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/trusted-types/pull/562.html" title="Last updated on Nov 6, 2024, 8:35 AM UTC (f2f903a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/562/72ecd2c...fred-wang:f2f903a.html" title="Last updated on Nov 6, 2024, 8:35 AM UTC (f2f903a)">Diff</a>