### PR TITLE
Put trusted type first when declaring union in IDL files

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1146,10 +1146,10 @@ Note: Using these IDL attributes is the recommended way of dynamically setting t
 
 <pre class="idl exclude">
 partial interface HTMLScriptElement {
- [CEReactions] attribute ([LegacyNullToEmptyString] DOMString or TrustedScript) innerText;
- [CEReactions] attribute (DOMString or TrustedScript)? textContent;
- [CEReactions] attribute (USVString or TrustedScriptURL) src;
- [CEReactions] attribute (DOMString or TrustedScript) text;
+ [CEReactions] attribute (TrustedScript or [LegacyNullToEmptyString] DOMString) innerText;
+ [CEReactions] attribute (TrustedScript or DOMString)? textContent;
+ [CEReactions] attribute (TrustedScriptURL or USVString) src;
+ [CEReactions] attribute (TrustedScript or DOMString) text;
 };
 </pre>
 


### PR DESCRIPTION
This is for consistency with how it is done in the HTML specification and in the PR to DOM (https://github.com/whatwg/dom/pull/1268). This is not web-exposed but may matter for implementations. For example, they may generate different C++ structure to represent `(TrustedHTML or DOMString)` and `(DOMString or TrustedHTML)`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/trusted-types/pull/564.html" title="Last updated on Nov 18, 2024, 7:27 AM UTC (8e1fa0f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/564/4317ed0...fred-wang:8e1fa0f.html" title="Last updated on Nov 18, 2024, 7:27 AM UTC (8e1fa0f)">Diff</a>