### PR TITLE
Add missing parameter name for algorithm

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1086,7 +1086,7 @@ Given an {{HTMLScriptElement}} or {{SVGScriptElement}} (|script|), this algorith
     set |script|'s [=script text=] to the result of executing [$Get Trusted Type compliant string$], with the following arguments:
       * {{TrustedScriptURL}} as |expectedType|,
       * |script|'s {{Document}}'s [=relevant global object=] as |global|,
-      * |script|'s [=child text content=] attribute value,
+      * |script|'s [=child text content=] attribute value as |input|,
       * |sink|,
       * `'script'` as |sinkGroup|.
 


### PR DESCRIPTION
It currently lists all parameters explicitly, except for `input`. While implementing this algorithm in Servo, I was confused what the value of `input` is supposed to be. Then I saw that it is probably the third argument, so let's make that explicit.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TimvdLippe/trusted-types/pull/585.html" title="Last updated on Apr 13, 2025, 9:06 AM UTC (322c6b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/585/279d0dd...TimvdLippe:322c6b8.html" title="Last updated on Apr 13, 2025, 9:06 AM UTC (322c6b8)">Diff</a>