### PR TITLE
Make get trusted types-compliant attribute value take strings instead…

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1197,12 +1197,13 @@ Given an {{HTMLScriptElement}} or {{SVGScriptElement}} (|script|), this algorith
     If the algorithm threw an error, rethrow the error.
 
 ## Get Trusted Types-compliant attribute value ## {#validate-attribute-mutation}
-To <dfn abstract-op export>get Trusted Types-compliant attribute value</dfn> on {{Attr}} |attribute| with {{Element}} |element| and {{TrustedType}} or a string |newValue|, perform the following steps:
+To <dfn abstract-op export>get Trusted Types-compliant attribute value</dfn> given a string |attributeName|, string |attributeNs|, {{Element}} |element| and {{TrustedType}} or a string |newValue|, perform the following steps:
 
+1. If |attributeNs| is the empty string, set |attributeNs| to null.
 1. Set |attributeData| to the result of [$Get Trusted Type data for attribute$] algorithm, with the following arguments:
     * |element|
-    * |attribute|'s <a for="Attr">local name</a> as |attribute|
-    * |attribute|'s <a for="Attr">namespace</a> as |attributeNs|
+    * |attributeName|
+    * |attributeNs|
 1. If |attributeData| is null, then:
     1. If |newValue| is a string, return |newValue|.
     1. <a>Assert</a>: |newValue| is {{TrustedHTML}} or {{TrustedScript}} or {{TrustedScriptURL}}.


### PR DESCRIPTION
… of an Attr object

This will allow the DOM specification to be cleaner


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/590.html" title="Last updated on Jul 3, 2025, 8:46 AM UTC (1887075)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/590/bdaf020...lukewarlow:1887075.html" title="Last updated on Jul 3, 2025, 8:46 AM UTC (1887075)">Diff</a>