### PR TITLE
Add TrustedTransformStream for streaming injection sinks

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -515,6 +515,20 @@ The value is set when the object is created, and will never change during its li
 <dfn dfn for="TrustedHTML">stringification behavior</dfn> steps of a
 TrustedHTML object are to return the associated [=TrustedHTML/data=] value.
 
+### <dfn interface>TrustedTransformStream</dfn> ### {#trusted-transform-stream}
+
+The TrustedTransformStream interface represents a {{TransformStream}} that a
+{{ReadableStream}} is piped through, so that the result can confidently be
+piped into an [=injection sink=] that expects a {{ReadableStream}}.
+These objects are constructed via a {{TrustedTypePolicy}}'s
+{{TrustedTypePolicy/createTransformStream()}} method.
+
+<pre class="idl">
+[Exposed=(Window,Worker)]
+interface TrustedTransformStream : TransformStream {
+};
+</pre>
+
 ### <dfn interface>TrustedScript</dfn> ### {#trusted-script}
 
 The TrustedScript interface represents a string with an uncompiled
@@ -899,6 +913,7 @@ throws a TypeError if a conversion of a given value is disallowed.
 interface TrustedTypePolicy {
   readonly attribute DOMString name;
   TrustedHTML createHTML(DOMString input, any... arguments);
+  TrustedTransformStream createTransformStream(any... arguments);
   TrustedScript createScript(DOMString input, any... arguments);
   TrustedScriptURL createScriptURL(DOMString input, any... arguments);
 };
@@ -921,6 +936,21 @@ Each TrustedTypePolicy object has an associated {{TrustedTypePolicyOptions}} <df
       <dd>`"TrustedHTML"`</dd>
       <dt>value</dt>
       <dd>input</dd>
+      <dt>arguments</dt>
+      <dd>arguments</dd>
+    </dl>
+
+: <dfn>createTransformStream(...arguments)</dfn>
+::  Returns the
+    result of executing the [$Create a Trusted Type$] algorithm, with the
+    following arguments:
+    <dl>
+      <dt>policy</dt>
+      <dd>[=this=] value</dd>
+      <dt>trustedTypeName</dt>
+      <dd>`"TrustedTransformStream"`</dd>
+      <dt>value</dt>
+      <dd>null</dd>
       <dt>arguments</dt>
       <dd>arguments</dd>
     </dl>
@@ -968,10 +998,12 @@ object instances directly - this behavior is provided by
 <pre class="idl">
 dictionary TrustedTypePolicyOptions {
    CreateHTMLCallback createHTML;
+   CreateTransformStreamCallback createTransformStream;
    CreateScriptCallback createScript;
    CreateScriptURLCallback createScriptURL;
 };
 callback CreateHTMLCallback = DOMString? (DOMString input, any... arguments);
+callback CreateTransformStreamCallback = TransformStream (any... arguments);
 callback CreateScriptCallback = DOMString? (DOMString input, any... arguments);
 callback CreateScriptURLCallback = USVString? (DOMString input, any... arguments);
 </pre>
@@ -1078,6 +1110,7 @@ a string (|policyName|), {{TrustedTypePolicyOptions}} dictionary (|options|), an
 1.  Set |policy|'s `name` property value to |policyName|.
 1.  Set |policy|'s [=TrustedTypePolicy/options=] value to «[
       "createHTML" -> |options|["{{TrustedTypePolicyOptions/createHTML|createHTML}}",
+      "createTransformStream" -> |options|["{{TrustedTypePolicyOptions/createTransformStream|createTransformStream}}",
       "createScript" -> |options|["{{TrustedTypePolicyOptions/createScript|createScript}}",
       "createScriptURL" -> |options|["{{TrustedTypePolicyOptions/createScriptURL|createScriptURL}}"
     ]».
@@ -1113,6 +1146,10 @@ a string |value|, a list |arguments|, and a boolean |throwIfMissing|, execute th
       <tr>
         <td>"createHTML"</td>
         <td>"TrustedHTML"</td>
+      </tr>
+      <tr>
+        <td>"createTransformStream"</td>
+        <td>"TrustedTransformStream"</td>
       </tr>
       <tr>
         <td>"createScript"</td>


### PR DESCRIPTION
This is intended to be used for document patching, where new methods of
streaming HTML into an element are introduced:
https://github.com/WICG/declarative-partial-updates/blob/main/patching-explainer.md

The aim is to ensure that for example `element.patchUnsafe()` returning
a `WritableStream` is piped through a policy-controlled
`TransformStream`.

Fixes https://github.com/w3c/trusted-types/issues/594.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/trusted-types/pull/597.html" title="Last updated on Sep 5, 2025, 3:06 PM UTC (12adfaf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/597/fbd1144...foolip:12adfaf.html" title="Last updated on Sep 5, 2025, 3:06 PM UTC (12adfaf)">Diff</a>