### PR TITLE
Add missing getter steps for HTMLScriptElement.src

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1338,6 +1338,20 @@ Update the {{HTMLScriptElement/text}} setter steps algorithm as follows.
 
 #### The {{HTMLScriptElement/src}} IDL attribute #### {#the-src-idl-attribute}
 
+The {{HTMLScriptElement/src}} getter steps are:
+
+1. <ins>Let |element| be the result of running [=this=]'s [=get the element=].</ins>
+
+1. <ins>Let |contentAttributeValue| be the result of running [=this=]'s [=get the content attribute=].</ins>
+
+1. <ins>If |contentAttributeValue| is null, then return the empty string.</ins>
+
+1. <ins>Let |urlString| be the result of encoding-parsing-and-serializing a URL given |contentAttributeValue|, relative to |element|'s [=node document=].</ins>
+
+1. <ins>If |urlString| is not failure, then return |urlString|.</ins>
+
+1. <ins>Return |contentAttributeValue|, [=converted to a scalar value string=].
+
 The {{HTMLScriptElement/src}} setter steps are:
 
 1.  <ins>Let |value| be the result of calling [$Get Trusted Type compliant string$] with


### PR DESCRIPTION
Fixes #600 

The HTML spec was updated to use [ReflectURL] here but it adds a getter and setter that uses reflection, this setter can't be used with TT so we need to add manual getter steps again which handles what [ReflectURL] would do.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/trusted-types/pull/601.html" title="Last updated on Oct 7, 2025, 2:26 PM UTC (44d53ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/601/fbd1144...lukewarlow:44d53ea.html" title="Last updated on Oct 7, 2025, 2:26 PM UTC (44d53ea)">Diff</a>