### PR TITLE
Enable createParserOptions, passing a sanitizer to trusted types

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -563,6 +563,28 @@ The value is set when the object is created, and will never change during its li
 <dfn for="TrustedScriptURL">stringification behavior</dfn> steps of a
 TrustedScriptURL object are to return the associated [=TrustedScriptURL/data=] value.
 
+### <dfn interface>TrustedParserOptions</dfn> ### {#trused-parser-options}
+
+The TrustedParserOptions interface represents a dictionary that a developer
+can confidently pass into an [=injection sink=] that will parse it as a URL of
+an external script resource.
+These objects are immutable wrappers around a
+{{SetHTMLUnsafeOptions}} dictionary, constructed via a {{TrustedTypePolicy}}'s
+{{TrustedTypePolicy/createParserOptions(options)|createParserOptions}} method.
+
+<pre class="idl">
+
+typedef (Sanitizer or SanitizerConfig or SanitizerPresets) SanitizerInput;
+
+[Exposed=(Window,Worker)]
+interface TrustedParserOptions {
+  readonly attribute SanitizerInput sanitizer;
+};
+</pre>
+
+{{TrustedParserOptions}} objects have an associated {{SanitizerInput}} <dfn export for="TrustedParserOptions">sanitizer</dfn>.
+The value is set when the object is created, and will never change during its lifetime.
+
 ## <dfn>Policies</dfn> ## {#policies-hdr}
 
 Trusted Types can only be created via user-defined
@@ -659,6 +681,32 @@ that it's called only with no attacker-controlled values.
 })();
 </xmp>
 </div>
+
+### Using together with a sanitizer ### {#trusted-types-with-sanitizer}
+
+While trusted types are built in a way that allows custom sanitizers to be used,
+the {{TrustedTypePolicy/createParserOptions(options)|createParserOptions}} also allows for using them as a way to enforce
+using the built-in sanitizer API. [[SANITIZER-API]]
+
+<div class="example" id="trusted-types-with-sanitizer-example">
+<xmp highlight=js>
+(function renderFootnote() {
+  const footnote = await fetch('/footnote.html').then(r => r.text());
+  footNote.setHTMLUnsafe(footnote, trustedTypes.createPolicy('html', {
+    createParserOptions: options => {
+      const sanitizer = new Sanitizer(options.sanitizer || {});
+      sanitizer.removeElement("script");
+      return {
+        sanitizer,
+      };
+    }
+  }).createParserOptions({}));
+})();
+</xmp>
+</div>
+
+Note: `createParserOptions` does not necessarily replace `createHTML`. If both exist in the policy, the `createHTML` function will be called first,
+and the result will be sanitized using the result of the `createParserOptions` function, if that exists.
 
 ### <dfn interface>TrustedTypePolicyFactory</dfn> ### {#trusted-type-policy-factory}
 
@@ -901,6 +949,7 @@ interface TrustedTypePolicy {
   TrustedHTML createHTML(DOMString input, any... arguments);
   TrustedScript createScript(DOMString input, any... arguments);
   TrustedScriptURL createScriptURL(DOMString input, any... arguments);
+  TrustedParserOptions createParserOptions(SetHTMLUnsafeOptions options, any... arguments);
 };
 </pre>
 
@@ -956,6 +1005,21 @@ Each TrustedTypePolicy object has an associated {{TrustedTypePolicyOptions}} <df
       <dd>arguments</dd>
     </dl>
 
+: <dfn>createParserOptions(options)</dfn>
+::  Returns the
+    result of executing the [=Create a Trusted Type=] algorithm, with the
+    following arguments:
+    <dl>
+      <dt>policy</dt>
+      <dd>[=this=] value</dd>
+      <dt>trustedTypeName</dt>
+      <dd>`"TrustedParserOptions"`</dd>
+      <dt>value</dt>
+      <dd>options</dd>
+      <dt>arguments</dt>
+      <dd>arguments</dd>
+    </dl>
+
 </div>
 
 ### <dfn dictionary>TrustedTypePolicyOptions</dfn> ### {#trusted-type-policy-options}
@@ -970,10 +1034,12 @@ dictionary TrustedTypePolicyOptions {
    CreateHTMLCallback createHTML;
    CreateScriptCallback createScript;
    CreateScriptURLCallback createScriptURL;
+   CreateParserOptionsCallback createParserOptions;
 };
 callback CreateHTMLCallback = DOMString? (DOMString input, any... arguments);
 callback CreateScriptCallback = DOMString? (DOMString input, any... arguments);
 callback CreateScriptURLCallback = USVString? (DOMString input, any... arguments);
+callback CreateParserOptionsCallback = SetHTMLUnsafeOptions? (SetHTMLUnsafeOptions options, any... arguments);
 </pre>
 
 ### <dfn data-lt="default-policy-explanation">Default policy</dfn> ### {#default-policy-hdr}
@@ -1077,9 +1143,10 @@ a string (|policyName|), {{TrustedTypePolicyOptions}} dictionary (|options|), an
 1.  Let |policy| be a new {{TrustedTypePolicy}} object.
 1.  Set |policy|'s `name` property value to |policyName|.
 1.  Set |policy|'s [=TrustedTypePolicy/options=] value to «[
-      "createHTML" -> |options|["{{TrustedTypePolicyOptions/createHTML|createHTML}}",
-      "createScript" -> |options|["{{TrustedTypePolicyOptions/createScript|createScript}}",
-      "createScriptURL" -> |options|["{{TrustedTypePolicyOptions/createScriptURL|createScriptURL}}"
+      "createHTML" -> |options|["{{TrustedTypePolicyOptions/createHTML|createHTML}}"],
+      "createScript" -> |options|["{{TrustedTypePolicyOptions/createScript|createScript}}"],
+      "createScriptURL" -> |options|["{{TrustedTypePolicyOptions/createScriptURL|createScriptURL}}"],
+      "createParserOptions" -> |options|["{{TrustedTypePolicyOptions/createParserOptions|createParserOptions}}"]
     ]».
 1.  If the |policyName| is `default`, set the |factory|'s [=TrustedTypePolicyFactory/default policy=] value to |policy|.
 1.  [=set/append|Append=] |policyName| to |factory|'s [=created policy names=].
@@ -1092,6 +1159,10 @@ a string |value| and a list |arguments|, perform the following steps:
 
 1.  Let |policyValue| be the result of executing [=get trusted type policy value=] with the same arguments as this algorithm and additionally true as |throwIfMissing|.
 1.  If the algorithm threw an error, rethrow the error and abort the following steps.
+1. If |trustedTypeName| is "TrustedParserOptions":
+  1. Let |sanitizer| be an empty {{SanitizerConfig}}.
+  1. If |policyValue| is a [=dictionary=] and has a property named "sanitizer", set |sanitizer| to |policyValue|["sanitizer"].
+  1. Return a new interface of {{TrustedTypePolicyOptions}} with its [=TrustedParserOptions/sanitizer=] set to |sanitizer|.
 1.  Let |dataString| be the result of stringifying |policyValue|.
 1.  If |policyValue| is null or undefined, set |dataString| to the empty string.
 1.  Return a new instance of an interface with a type
@@ -1121,6 +1192,10 @@ a string |value|, a list |arguments|, and a boolean |throwIfMissing|, perform th
       <tr>
         <td>"createScriptURL"</td>
         <td>"TrustedScriptURL"</td>
+      </tr>
+      <tr>
+        <td>"createParserOptions"</td>
+        <td>"TrustedParserOptions"</td>
       </tr>
     </table>
 
@@ -1159,6 +1234,28 @@ To <dfn export>get trusted type compliant string</dfn> a {{TrustedType}} type (|
     1. Throw a TypeError and abort further steps.
 1. Assert: |convertedInput| is an instance of |expectedType|.
 1. Return stringified |convertedInput|.
+
+
+## Get Trusted Type compliant parser options ## {#get-trusted-type-compliant-parser-options-algorithm}
+
+To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/global object=] (|global|),
+{{TrustedParserOptions}} or a {{SetHTMLOptions}} or a {{SetHTMLUnsafeOptions}} (|input|), a string (|sink|) and a string (|sinkGroup|), run these steps:
+
+1.  If |input| is an instance of {{TrustedParserOptions}}, return |input| and abort these steps.
+1.  Let |requireTrustedTypes| be the result of executing [=Does sink type require trusted types?=] algorithm,
+    passing |global|, |sinkGroup|, and true.
+1.  If |requireTrustedTypes| is `false`, return |input| and abort these steps.
+1.  Let |convertedInput| be the result of executing [=Process value with a default policy=] with the same arguments as this algorithm.
+1.  If the algorithm threw an error, rethrow the error and abort the following steps.
+1.  If |convertedInput| is `null` or `undefined`, execute the following steps:
+    1.  Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
+        passing |global|, stringified |input| as |source|, |sinkGroup| and |sink|.
+    1.  If |disposition| is `“Allowed”`, return |input| and abort further steps.
+
+        Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.
+    1. Throw a TypeError and abort further steps.
+1. Assert: |convertedInput| is an instance of |expectedType|.
+1. Return |convertedInput|.
 
 ## Process value with a default policy ## {#process-value-with-a-default-policy-algorithm}
 
@@ -1207,7 +1304,7 @@ To <dfn export>get trusted type compliant attribute value</dfn> given a string |
     * |attributeNs|
 1. If |attributeData| is null, then:
     1. If |newValue| is a string, return |newValue|.
-    1. <a>Assert</a>: |newValue| is {{TrustedHTML}} or {{TrustedScript}} or {{TrustedScriptURL}}.
+    1. <a>Assert</a>: |newValue| is {{TrustedHTML}} or {{TrustedScript}} or {{TrustedScriptURL}} or {{TrustedParserOptions}}.
     1. Return |value|'s associated data.
 1. Let |expectedType| be the value of the fourth member of |attributeData|.
 1. Let |sink| be the value of the fifth member of |attributeData|.
@@ -1220,7 +1317,7 @@ To <dfn export>get trusted type compliant attribute value</dfn> given a string |
 
    If the algorithm threw an error, rethrow the error.
 
-## Get Trusted Type data for attribute ## {#get-trusted-type-data-for-attribute}
+## Get Trusted Type data for attribute ## {#get-trusted-type-data-for-attribute-algorithm}
 
 To <dfn>get Trusted Type data for attribute</dfn> given |element|, |attribute|, |attributeNs|, perform the following steps:
 
@@ -1249,7 +1346,7 @@ Issue: The [=event handler content attribute=] concept used below is ambiguous. 
 # Integrations # {#integrations}
 
 <pre class="idl">
-typedef (TrustedHTML or TrustedScript or TrustedScriptURL) TrustedType;
+typedef (TrustedHTML or TrustedScript or TrustedScriptURL or TrustedParserOptions) TrustedType;
 </pre>
 
 ## Integration with HTML ## {#integration-with-html}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -576,7 +576,7 @@ These objects are immutable wrappers around a
 
 typedef (Sanitizer or SanitizerConfig or SanitizerPresets) SanitizerInput;
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window)]
 interface TrustedParserOptions {
   readonly attribute SanitizerInput sanitizer;
 };

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -692,7 +692,7 @@ using the built-in sanitizer API. [[SANITIZER-API]]
 <xmp highlight=js>
 (function renderFootnote() {
   const footnote = await fetch('/footnote.html').then(r => r.text());
-  footNote.setHTMLUnsafe(footnote, trustedTypes.createPolicy('html', {
+  const policy = trustedTypes.createPolicy('html', {
     createParserOptions: options => {
       const sanitizer = new Sanitizer(options.sanitizer || {});
       sanitizer.removeElement("script");
@@ -700,7 +700,8 @@ using the built-in sanitizer API. [[SANITIZER-API]]
         sanitizer,
       };
     }
-  }).createParserOptions({}));
+  });
+  footNote.setHTMLUnsafe(footnote, policy.createParserOptions({}));
 })();
 </xmp>
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1136,6 +1136,73 @@ via using the <a http-header>Content-Security-Policy-Report-Only</a> HTTP Respon
 Note: Most of the enforcement rules are defined as modifications of the
 algorithms in other specifications, see [[#integrations]].
 
+### Sanitization enforcement with {{TrustedTypePolicy/createParserOptions(options)|createParserOptions}} ### {#sanitization-enforcement-hdr}
+
+While {{TrustedTypePolicyOptions/createHTML|createHTML}} relies on sanitizing strings before they are injected to the parser using a JS sanitizer,
+the {{TrustedTypePolicy/createParserOptions(options)|createParserOptions}} allows the page's default policy to enforce HTML sanitization.
+
+A {{TrustedTypePolicy/createParserOptions(options)|createParserOptions}} callback in a required default policy would run for
+any attempt to inject HTML into a document using script.
+
+<div class="example" id="require-sanitizer-for-html-injection">
+Enforce Trusted Types at the DOM XSS injection sinks.
+
+<pre class="http">
+Content-Security-Policy: require-trusted-types-for 'script'
+</pre>
+
+Inject a sanitizer when using an HTML injection sink.
+
+<xmp highlight=js>
+(function renderFootnote() {
+  const defaultPolicy = trustedTypes.createPolicy('default', {
+    createParserOptions: options => {
+      const sanitizer = new Sanitizer(options.sanitizer)
+      sanitizer.removeUnsafe();
+      return { ...options, sanitizer };
+    }
+  });
+
+  const trustedOptions = trustedTypes.createPolicy('trusted', {
+    createParserOptions: options => options
+  }).createParserOptions({});
+  const untrustedFootnoteContent = await fetch('/footnote.html').then(r => r.text());
+
+  // This HTML will be sanitized with a "safe" HTML sanitizer, as the default policy injects
+  // a sanitizer with unsafe markup removed.
+  footNote.innerHTML = untrustedFootnoteContent;
+  // or:
+  footNote.setHTMLUnsafe(untrustedFootnoteContent, {});
+  const trustedMainContent = await fetch("main.html").then(r => r.text());
+  main.setHTMLUnsafe(trustedMainContent, trustedOptions);
+})();
+</xmp>
+
+Apart from sanizitation, the default policy can also prevent an HTML injection from running scripts.
+
+<xmp highlight=js>
+(function renderFootnote() {
+  const defaultPolicy = trustedTypes.createPolicy('default', {
+    createParserOptions: options => {
+      return { ...options, runScripts: false };
+    }
+  });
+
+  // The default policy would override the {{SetHTMLUnsafeOptions/runScripts}} value to false.
+  main.setHTMLUnsafe(someHTMLWithScripts, {runScripts: true});
+
+  // This applies to {{Range/createContextualFragment(string)}}
+  const fragment = new Range().createContextualFragment("<script>alert(1)</" + "script>");
+  const div = document.createElement('div');
+  // The scripts in the fragment would not be executed, as the default policy overrides {{SetHTMLUnsafeOptions/runScripts}}.
+  div.appendChild(fragment);
+})();
+</xmp>
+
+</div>
+
+
+
 # Algorithms # {#algorithms}
 
 ## Create a Trusted Type Policy ## {#create-trusted-type-policy-algorithm}
@@ -1225,7 +1292,9 @@ a string |value|, a list |arguments|, and a boolean |throwIfMissing|, perform th
 ## Get Trusted Type parser input ## {#get-trusted-type-parser-input-algorithm}
 
 To <dfn export>get Trusted Type compliant input</dfn> given a {{TrustedType}} |expectedType|, a [=realm/global object=] (|global|), string, or <code data-x="">Stream</code> |input|,
-a {{TrustedParserOptions}}, {{SetHTMLUnsafeOptions}} or <code data-x="">Legacy</code> |options|, a string (|sink|) and a string (|sinkGroup|), run these steps:
+a {{TrustedParserOptions}}, {{SetHTMLUnsafeOptions}} or <code data-x="">Legacy</code> |options|, and a string (|sink|), run these steps:
+
+1. Let |sinkGroup| be 
 
 1. If |input| is not a <code data-x="">Stream</code>:
   1. Set |input| to the result of calling get trusted type compliant string, passing |expectedType|, |global|, |input|, |sink| and |sinkGroup|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1523,7 +1523,7 @@ Issue: The [=event handler content attribute=] concept used below is ambiguous. 
 # Integrations # {#integrations}
 
 <pre class="idl">
-typedef (TrustedHTML or TrustedScript or TrustedScriptURL or TrustedParserOptions) TrustedType;
+typedef (TrustedHTML or TrustedScript or TrustedScriptURL) TrustedType;
 </pre>
 
 ## Integration with HTML ## {#integration-with-html}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -573,12 +573,11 @@ TrustedScriptURL object are to return the associated [=TrustedScriptURL/data=] v
 
 ### <dfn interface>TrustedParserOptions</dfn> ### {#trused-parser-options}
 
-The {{TrustedParserOptions}} interface represents a dictionary that a developer
-can confidently pass into an [=injection sink=] that will parse it as a URL of
-an external script resource.
+The {{TrustedParserOptions}} interface represents options that a developer
+can confidently pass into an [=injection sink=] that will parse HTML.
 These objects are immutable wrappers around a
 {{SetHTMLUnsafeOptions}} dictionary, constructed via a {{TrustedTypePolicy}}'s
-{{TrustedTypePolicy/createParserOptions(options)|createParserOptions}} method.
+{{TrustedTypePolicy/createParserOptions(options, ...arguments)|createParserOptions}} method.
 
 <pre class="idl">
 
@@ -1032,7 +1031,7 @@ Each TrustedTypePolicy object has an associated {{TrustedTypePolicyOptions}} <df
       <dd>arguments</dd>
     </dl>
 
-: <dfn>createParserOptions(options)</dfn>
+: <dfn>createParserOptions(options, ...arguments)</dfn>
 ::  Returns the
     result of executing the [=Create a Trusted Type=] algorithm, with the
     following arguments:
@@ -1195,7 +1194,7 @@ Inject a sanitizer when using an HTML injection sink.
 })();
 </xmp>
 
-Apart from sanizitation, the default policy can also prevent an HTML injection from running scripts.
+Apart from sanitization, the default policy can also prevent an HTML injection from running scripts.
 HTML inserted with {{SetHTMLUnsafeOptions/runScripts}} set to false can still insert `script` elements into the document,
 but those scripts are not automatically executed.
 
@@ -1251,19 +1250,19 @@ a string (|policyName|), {{TrustedTypePolicyOptions}} dictionary (|options|), an
 ## Create a Trusted Type ## {#create-a-trusted-type-algorithm}
 
 To <dfn>create a trusted type</dfn> given a {{TrustedTypePolicy}} |policy|, a type name |trustedTypeName|,
-a string |value| and a list |arguments|, perform the following steps:
+a string or dictionary |value| and a list |arguments|, perform the following steps:
 
 1.  Let |policyValue| be the result of executing [=get trusted type policy value=] with the same arguments as this algorithm and additionally true as |throwIfMissing|.
 1.  If the algorithm threw an error, rethrow the error and abort the following steps.
 1.  If |trustedTypeName| is `"TrustedParserOptions"`:
-    1.  Let |sanitizer| be a new {{SanitizerConfig}}.
+    1.  Let |sanitizer| be null.
     1.  Let |runScripts| be false.
     1.  If |policyValue| is a [=dictionary=]:
         1.  Set |sanitizer| to the result of
             [=get a sanitizer config from dictionary|getting a sanitizer configuration=]
             from |policyValue|.
         1.  Set |runScripts| to |policyValue|["runScripts"] [=with default=] false.
-    1.  Return a new instance of {{TrustedParserOptions}} with its
+    1.  Return a new instance of {{TrustedParserOptions}} in |policy|'s [=relevant realm=] with its
         [=TrustedParserOptions/sanitizer config=] set to |sanitizer|, and its
         [=TrustedParserOptions/runScripts=] set to |runScripts|.
 1.  Let |dataString| be the result of stringifying |policyValue|.
@@ -1274,7 +1273,7 @@ a string |value| and a list |arguments|, perform the following steps:
 ## Get Trusted Type policy value ## {#get-trusted-type-policy-value-algorithm}
 
 To <dfn>get trusted type policy value</dfn> given a {{TrustedTypePolicy}} |policy|, a type name |trustedTypeName|,
-a string |value|, a list |arguments|, and a boolean |throwIfMissing|, perform the following steps:
+a string or dictionary |value|, a list |arguments|, and a boolean |throwIfMissing|, perform the following steps:
 
 1.  Let |functionName| be a function name for the given |trustedTypeName|,
     based on the following table:
@@ -1341,7 +1340,7 @@ To <dfn export>get trusted type compliant string</dfn> a {{TrustedType}} type (|
 1.  If the algorithm threw an error, rethrow the error and abort the following steps.
 1.  If |convertedInput| is `null` or `undefined`, execute the following steps:
     1.  Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
-        passing |global|, stringified |input| as |source|, |sinkGroup| and |sink|.
+        passing |global|, |sink|, |sinkGroup|, and stringified |input| as |source|.
     1.  If |disposition| is `“Allowed”`, return stringified |input| and abort further steps.
 
         Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.
@@ -1358,7 +1357,7 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
 
 1.  If |input| is an instance of {{TrustedParserOptions}}, return |input|.
 1.  Let |requireTrustedTypes| be the result of executing [=Does sink type require trusted types?=] algorithm,
-    passing |global|, `"TrustedHTML"`, and true.
+    passing |global|, `"script"`, and true.
 1.  If |requireTrustedTypes| is `false`, return |input|.
 1.  Let |defaultPolicy| be the value of |global|'s [=Window/trusted type policy factory=]'s [=TrustedTypePolicyFactory/default policy=].
 1.  If |defaultPolicy| is null, throw a {{TypeError}}.
@@ -1374,13 +1373,13 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
 1. If the algorithm threw an error, rethrow the error and abort the following steps.
 1. If |policyValue| is `null` or `undefined`:
     1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
-        passing |global|, |input|, `"TrustedHTML"` and |sink|.
+        passing |global|, |sink|, `"script"`, and stringified |input| as |source|.
     1. If |disposition| is `“Allowed”`, return |input|.
 
         Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.
 
     1. Throw a {{TypeError}}.
-1. Let |runScripts| be true if |policyValue|["`runScripts`"] is true and |input| is a {{SetHTMLUnsafeOptions}} whose {{SetHTMLUnsafeOptions/runScripts}} is true.
+1. Let |runScripts| be true if |policyValue|["runScripts"] is true and |input| is a {{SetHTMLUnsafeOptions}} whose {{SetHTMLUnsafeOptions/runScripts}} is true.
 1. Return a new {{TrustedParserOptions}} in |global|'s [=relevant realm=]
     whose [=TrustedParserOptions/sanitizer config=] is set to the result of
     [=get a sanitizer config from dictionary|getting a sanitizer configuration=] from
@@ -1388,7 +1387,7 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
     and whose [=TrustedParserOptions/runScripts=] is set to |runScripts|.
 
 To <dfn>get a sanitizer config from dictionary</dfn> given a dictionary |dictionary|:
-1. Let |sanitizerInput| be |dictionary|["`sanitizer`"], [=with default|defaulting to=] null.
+1. Let |sanitizerInput| be |dictionary|["sanitizer"], [=with default|defaulting to=] null.
 1. If |sanitizerInput| is a {{Sanitizer}}, set it to |sanitizerInput|'s
     [=Sanitizer/configuration=].
 1. Return |sanitizerInput|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1313,11 +1313,11 @@ a string |value|, a list |arguments|, and a boolean |throwIfMissing|, perform th
 
 ## Get Trusted Type parser input ## {#get-trusted-type-parser-input-algorithm}
 
-To <dfn export>get Trusted Type compliant input</dfn> given a {{TrustedType}} |expectedType|, a [=realm/global object=] |global|, a string or <code data-x="">Stream</code> |input|,
+To <dfn export>get Trusted Type compliant input</dfn> given a [=realm/global object=] |global|, a string or <code data-x="">Stream</code> |input|,
 a {{TrustedParserOptions}} or {{SetHTMLUnsafeOptions}} |options|, and a string |sink|:
 
 1. If |input| is not a <code data-x="">Stream</code>:
-    1. Set |input| to the result of calling get trusted type compliant string, passing |expectedType|, |global|, |input|, |sink|, and `"TrustedHTML"`.
+    1. Set |input| to the result of calling [=get trusted type compliant string=], passing `"TrustedHTML"`, |global|, |input|, |sink|, and `"script"`.
     1. If the algorithm threw an error, rethrow the error.
 1. Let |throwIfMissing| be true if |input| is not a <code data-x="">Stream</code>; otherwise false.
 1. Set |options| to the result of calling [=get Trusted Type compliant parser options=], passing |global|, |options|, |throwIfMissing|, and |sink|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -236,6 +236,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     type: dfn; text: event handler content attribute; url: event-handler-content-attributes
     type: dfn; text: built-in safe default configuration; url: built-in-safe-default-configuration
     type: dfn; text: configuration; for: Sanitizer; url: configuration
+    type: dfn; text: configure; for: Sanitizer; url: configure-a-sanitizer
+    type: dfn; text: configure a sanitizer; url: configure-a-sanitizer
     type: dfn; text: canonicalize the configuration; url: canonicalize-the-configuration
     type: dfn; text: valid; for: SanitizerConfig; url: dom-sanitizerconfig-valid
     type:interface; text:Sanitizer
@@ -599,8 +601,8 @@ The {{TrustedParserOptions/runScripts}} getter steps are to return [=this=]'s as
 The <dfn method for="TrustedParserOptions">sanitizer()</dfn> method steps are:
 
 1. If [=this=]'s [=TrustedParserOptions/sanitizer config=] is null, return null.
-1. Let |config| be the result of [=map/clone|cloning=] [=this=]'s [=TrustedParserOptions/sanitizer config=].
-1. Let |sanitizer| be a new {{Sanitizer}} in [=this=]'s [=relevant realm=], [=configure|configured=] with |config| and true.
+1. Let |sanitizer| be a new {{Sanitizer}} in [=this=]'s [=relevant realm=].
+1. [=configure a sanitizer|Configure=] |sanitizer| given [=this=]'s [=TrustedParserOptions/sanitizer config=] and true.
 1. Return |sanitizer|.
 
 </div>
@@ -1067,7 +1069,7 @@ dictionary TrustedTypePolicyOptions {
 callback CreateHTMLCallback = DOMString? (DOMString input, any... arguments);
 callback CreateScriptCallback = DOMString? (DOMString input, any... arguments);
 callback CreateScriptURLCallback = USVString? (DOMString input, any... arguments);
-callback CreateParserOptionsCallback = SetHTMLUnsafeOptions? (optional SetHTMLUnsafeOptions options = {}, any... arguments);
+callback CreateParserOptionsCallback = SetHTMLUnsafeOptions? (optional SetHTMLUnsafeOptions options, any... arguments);
 </pre>
 
 ### <dfn data-lt="default-policy-explanation">Default policy</dfn> ### {#default-policy-hdr}
@@ -1257,12 +1259,12 @@ a string or dictionary |value| and a list |arguments|, perform the following ste
 1.  If the algorithm threw an error, rethrow the error and abort the following steps.
 1.  If |trustedTypeName| is `"TrustedParserOptions"`:
     1.  If |policyValue| is not a [=dictionary=], throw a {{TypeError}}.
-    1.  Let |sanitizer| be the result of
+    1.  Let |sanitizerConfig| be the result of
         [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=]
         from |policyValue|.
     1.  Let |runScripts| be |policyValue|["runScripts"] [=with default=] false.
     1.  Return a new instance of {{TrustedParserOptions}} in |policy|'s [=relevant realm=] with its
-        [=TrustedParserOptions/sanitizer config=] set to |sanitizer|, and its
+        [=TrustedParserOptions/sanitizer config=] set to |sanitizerConfig|, and its
         [=TrustedParserOptions/runScripts=] set to |runScripts|.
 1.  Let |dataString| be the result of stringifying |policyValue|.
 1.  If |policyValue| is null or undefined, set |dataString| to the empty string.
@@ -1313,7 +1315,7 @@ a string or dictionary |value|, a list |arguments|, and a boolean |throwIfMissin
 ## Get Trusted Type compliant input ## {#get-trusted-type-compliant-input-algorithm}
 
 To <dfn export>get trusted type compliant input</dfn> given a [=realm/global object=] |global|, a string or {{TrustedHTML}} |input|,
-a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, and a string |sink|:
+a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, and a string |sink|, and an optional boolean |isXMLDocument| (default false):
 
 1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
 1. If the algorithm threw an error, rethrow the error.
@@ -1322,11 +1324,12 @@ a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions
     1. Let |sanitizerConfig| be |options|'s [=TrustedParserOptions/sanitizer config=] if |options| is an instance of {{TrustedParserOptions}}; otherwise the result of [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from |options|.
     1. Let |trustedOptions| be a new {{TrustedParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedParserOptions/sanitizer config=] is |sanitizerConfig| and whose [=TrustedParserOptions/runScripts=] is |runScripts|.
     1. Return (stringified |input|, |trustedOptions|).
-
-    Note: this means that when given {{TrustedHTML}} by the caller, the policy's {{TrustedTypePolicyOptions/createParserOptions}} callback can only be used to disable script execution.
-
 1. If |options| is an instance of {{TrustedParserOptions}}, return (stringified |input|, |compliantOptions|).
 1. If |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer config=] is not null:
+    1. If |isXMLDocument| is true:
+        1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
+            passing |global|, |sink|, `"script"`, and stringified |input| as |source|.
+        1. If |disposition| is "Blocked", throw a {{TypeError}}.
     1. Return (stringified |input|, |compliantOptions|).
 1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
 1. If the algorithm threw an error, rethrow the error.
@@ -1391,9 +1394,10 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
 1. Let |argument| be the [=ordered map=] «[ "runScripts" → |runScriptsInput| ]».
 1. Let |sanitizerInputConfig| be the results of [=get a sanitizer config copy from dictionary|getting a sanitizer config=] from |input|.
 1. If |sanitizerInputConfig| is not null:
-    1. Let |sanitizerInput| be a new {{Sanitizer}} in |global|'s [=relevant realm=], [=configure|configured=] with |sanitizerInputConfig| and true.
+    1. Let |sanitizerInput| be a new {{Sanitizer}} in |global|'s [=relevant realm=].
+    1. [=configure a sanitizer|Configure=] |sanitizerInput| given |sanitizerInputConfig| and true.
     1. Set |argument|["sanitizer"] to |sanitizerInput|.
-1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument|, |sink| » and `"rethrow"`.
+1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument|, "TrustedParserOptions", |sink| » and `"rethrow"`.
 1. If the algorithm threw an error, rethrow the error and abort the following steps.
 1. If |policyValue| is `null` or `undefined`:
     1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
@@ -1405,8 +1409,8 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
     1. Throw a {{TypeError}}.
 1. Let |runScripts| be true if |policyValue|["runScripts"] is true and |runScriptsInput| is true; otherwise false.
 
-  Note: The {{TrustedTypePolicyOptions/createParserOptions}} method can only disable script execution.
-  It cannot enable script execution when the caller did not request scripts to be executed in the first place.
+    Note: When invoked as a default policy, the {{TrustedTypePolicyOptions/createParserOptions}} callback can only disable script execution.
+    It cannot enable script execution when the caller did not request scripts to be executed in the first place.
 
 1. Return a new {{TrustedParserOptions}} in |global|'s [=relevant realm=]
     whose [=TrustedParserOptions/sanitizer config=] is set to the result of
@@ -1416,23 +1420,16 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
 
 To <dfn>get a sanitizer config copy from dictionary</dfn> given a dictionary |dictionary|:
 1. Let |sanitizerInput| be |dictionary|["sanitizer"], [=with default|defaulting to=] null.
-1. Let |config| be null.
 1. If |sanitizerInput| is a {{SanitizerPresets}}:
     1. [=Assert=]: |sanitizerInput| is `"default"`.
-    1. Set |config| to the [=built-in safe default configuration=].
-1. Otherwise if |sanitizerInput| is a {{Sanitizer}}:
-    1. Set |config| to |sanitizerInput|'s [=Sanitizer/configuration=].
-1. Otherwise if |sanitizerInput| is a {{SanitizerConfig}}:
-    1. Set |config| to |sanitizerInput|.
-1. Otherwise:
-    1. Return null.
-1. Set |config| to a [=map/clone=] of |config|.
-1. [=canonicalize the configuration|Canonicalize the configuration=] |config| with true.
-1. If |config| is not [=SanitizerConfig/valid=], then throw a {{TypeError}}.
-
-    Note: This creates a fresh copy of each list, leaving the original |config| immutable.
-
-1. Return |config|.
+    1. Return the [=built-in safe default configuration=].
+1. If |sanitizerInput| is a {{Sanitizer}}:
+    1. Return |sanitizerInput|'s [=Sanitizer/configuration=].
+1. If |sanitizerInput| is a {{SanitizerConfig}}:
+    1. Let |sanitizer| be a new {{Sanitizer}}.
+    1. [=configure a sanitizer|Configure=] |sanitizer| given |sanitizerInput| and true.
+    1. Return |sanitizer|'s [=Sanitizer/configuration=].
+1. Return null.
 
 ## Process value with a default policy ## {#process-value-with-a-default-policy-algorithm}
 
@@ -1494,7 +1491,7 @@ To <dfn export>get trusted type compliant attribute value</dfn> given a string |
 
    If the algorithm threw an error, rethrow the error.
 
-## Get Trusted Type data for attribute ## {#get-trusted-type-data-for-attribute-algo}
+## Get Trusted Type data for attribute ## {#get-trusted-type-data-for-attribute}
 
 To <dfn>get Trusted Type data for attribute</dfn> given |element|, |attribute|, |attributeNs|, perform the following steps:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1249,13 +1249,13 @@ a string |value| and a list |arguments|, perform the following steps:
 1.  Let |policyValue| be the result of executing [=get trusted type policy value=] with the same arguments as this algorithm and additionally true as |throwIfMissing|.
 1.  If the algorithm threw an error, rethrow the error and abort the following steps.
 1. If |trustedTypeName| is "TrustedParserOptions":
-  1. Let |sanitizer| be a new {{SanitizerConfig}}.
-  1. Let |runScripts| be false.
-  1. If |policyValue| is a [=dictionary=]:
-    1. Set |sanitizer| to the result of
-        [=get a sanitizer configuration from dictionary|getting a sanitizer configuration=]
-        from |policyValue|.
-    1. Set |runScripts| to |policyValue|["runScripts"] [=with default=] false.
+    1. Let |sanitizer| be a new {{SanitizerConfig}}.
+    1. Let |runScripts| be false.
+    1. If |policyValue| is a [=dictionary=]:
+        1. Set |sanitizer| to the result of
+            [=get a sanitizer configuration from dictionary|getting a sanitizer configuration=]
+            from |policyValue|.
+        1. Set |runScripts| to |policyValue|["runScripts"] [=with default=] false.
   1. Return a new instance of {{TrustedParserOptions}} with its
       [=TrustedParserOptions/sanitizer=] set to |sanitizer|, and its
       [=TrustedParserOptions/runScripts=] set to |runScripts|.
@@ -1310,14 +1310,12 @@ a string |value|, a list |arguments|, and a boolean |throwIfMissing|, perform th
 To <dfn export>get Trusted Type compliant input</dfn> given a {{TrustedType}} |expectedType|, a [=realm/global object=] |global|, a string or <code data-x="">Stream</code> |input|,
 a {{TrustedParserOptions}}, {{SetHTMLUnsafeOptions}} or <code data-x="">Legacy</code> |options|, and a string |sink|:
 
-1. Let |sinkGroup| be 
-
 1. If |input| is not a <code data-x="">Stream</code>:
-  1. Set |input| to the result of calling get trusted type compliant string, passing |expectedType|, |global|, |input|, |sink|, and |sinkGroup|.
-  1. If the algorithm threw an error, rethrow the error.
+    1. Set |input| to the result of calling get trusted type compliant string, passing |expectedType|, |global|, |input|, |sink|, and `"TrustedHTML"`.
+    1. If the algorithm threw an error, rethrow the error.
 1. If |options| is <code data-x="">Legacy</code>, set |options| to a new {{SetHTMLUnsafeOptions}} dictionary.
 1. Let |throwIfMissing| be true if |input| is not a <code data-x="">Stream</code>; otherwise false.
-1. Set |options| to the result of calling [=get Trusted Type compliant parser options=], passing |global|, |options|, |throwIfMissing|, |sink|, and |sinkGroup|.
+1. Set |options| to the result of calling [=get Trusted Type compliant parser options=], passing |global|, |options|, |throwIfMissing|, and |sink|.
 1. If the algorithm threw an error, rethrow the error.
 1. Return (|input|, |options|).
 
@@ -1352,11 +1350,11 @@ To <dfn export>get trusted type compliant string</dfn> a {{TrustedType}} type (|
 
 To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/global object=] |global|,
 |input|, which is either a {{TrustedParserOptions}}, a {{SetHTMLUnsafeOptions}}, or a {{ParseHTMLUnsafeOptions}},
-a boolean |throwIfMissing|, a string |sink| and a string |sinkGroup|, run these steps:
+a boolean |throwIfMissing|, and a string |sink|, run these steps:
 
 1.  If |input| is an instance of {{TrustedParserOptions}}, return |input|.
 1.  Let |requireTrustedTypes| be the result of executing [=Does sink type require trusted types?=] algorithm,
-    passing |global|, |sinkGroup|, and true.
+    passing |global|, `"TrustedHTML"`, and true.
 1.  If |requireTrustedTypes| is `false`, return |input|.
 1.  Let |defaultPolicy| be the value of |global|'s [=Window/trusted type policy factory=]'s [=TrustedTypePolicyFactory/default policy=].
 1.  If |defaultPolicy| is null, throw a {{TypeError}}.
@@ -1371,7 +1369,7 @@ a boolean |throwIfMissing|, a string |sink| and a string |sinkGroup|, run these 
 1. If the algorithm threw an error, rethrow the error and abort the following steps.
 1. If |policyValue| is `null` or `undefined`:
     1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
-        passing |global|, |input|, |sinkGroup| and |sink|.
+        passing |global|, |input|, `"TrustedHTML"` and |sink|.
     1. If |disposition| is `“Allowed”`, return |input|.
 
         Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -849,7 +849,7 @@ Its value is initially « ».
     1. If |elementNs| is null or an empty string, set |elementNs| to [=HTML namespace=].
     1. Let |interface| be the [=element interface=] for |localName| and |elementNs|.
     1. Let |expectedType| be null.
-    1. Find the row in the following table, where the first column is "*" or |interface|'s name, and |property| is in the second column.
+    1. Find the row in the following table, where the first column is "*" or |interface|'s name, and <var ignore="">property</var> is in the second column.
         If a matching row is found, set |expectedType| to the interface's name of the value of the third column.
 
         <table>
@@ -1362,7 +1362,7 @@ To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/g
 
     1. Throw a TypeError and abort further steps.
 1. Let |sanitizer| be |policyValue|["`sanitizer`"], [=with default|defaulting to=] a new {{SanitizerConfig}}.
-1. If |sanitizer| is a {{Sanitizer}}, then set |sanitizer| to a new {{Sanitizer}} whose [=Sanitizer/configuration=] is the result of [=canonicali`ze the configuration|canonicalizing=] |sanitizer|'s [=Sanitizer/configuration=].
+1. If |sanitizer| is a {{Sanitizer}}, then set |sanitizer| to a new {{Sanitizer}} whose [=Sanitizer/configuration=] is the result of [=canonicalize the configuration|canonicalizing=] |sanitizer|'s [=Sanitizer/configuration=].
 
   This step assures that the provided {{Sanitizer}} is not mutated by the policy.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1368,7 +1368,7 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
     1. Return |input|.
 1. Let |runScriptsInput| be |input|["runScripts"], [=with default=] false.
 1. Let |sanitizerInputConfig| be the results of [=get a sanitizer config from dictionary|getting a sanitizer config=] from |input|.
-1. Let |sanitizerInput| be null if |sanitizerInputConfig| is null; otherwise a new {{Sanitizer}}, [=configure|configured=] withh |sanitizerInputConfig|.
+1. Let |sanitizerInput| be null if |sanitizerInputConfig| is null; otherwise a new {{Sanitizer}}, [=configure|configured=] with |sanitizerInputConfig|.
 1. Let |argument| be the [=ordered map=] «[ "runScripts" → |runScriptsInput|, "sanitizer" → |sanitizerInput| ]».
 1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument| » and `"rethrow"`.
 1. If the algorithm threw an error, rethrow the error and abort the following steps.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -731,6 +731,9 @@ using the built-in sanitizer API.
 Note: `createParserOptions` does not necessarily replace `createHTML`. If both exist in the policy, the `createHTML` function will be called first,
 and the result will be sanitized using the result of the `createParserOptions` function, if that exists.
 
+Note: The `"sanitizer"` value only works with HTML documents. Returning a non-null value for `"sanitizer"` for XML documents throws an exception.
+When protecting XML documents, authors are advised to use `createHTML` instead and perform sanitization using JavaScript.
+
 ### <dfn interface>TrustedTypePolicyFactory</dfn> ### {#trusted-type-policy-factory}
 
 TrustedTypePolicyFactory creates
@@ -1367,6 +1370,7 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
 1. Let |runScriptsInput| be |input|["runScripts"], [=with default=] false.
 1. Let |sanitizerInputConfig| be the results of [=get a sanitizer config from dictionary|getting a sanitizer config=] from |input|.
 1. Let |sanitizerInput| be null if |sanitizerInputConfig| is null; otherwise a new {{Sanitizer}}, [=configure|configured=] withh |sanitizerInputConfig|.
+1. If |sanitizerInput| is not null and |global|'s [=associated Document=]'s [=Document/type=] is `"xml"`, throw a {{TypeError}}.
 1. Let |argument| be the [=ordered map=] «[ "runScripts" → |runScriptsInput|, "sanitizer" → |sanitizerInput| ]».
 1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument| » and `"rethrow"`.
 1. If the algorithm threw an error, rethrow the error and abort the following steps.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1353,7 +1353,7 @@ To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/g
 
 1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument| » and `"rethrow"`.
 1. If the algorithm threw an error, rethrow the error and abort the following steps.
-1. If |policyValue| is `null` or `undefined`, execute the following steps:
+1. If |policyValue| is `null` or `undefined`:
     1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
         passing |global|, |input|, |sinkGroup| and |sink|.
     1. If |disposition| is `“Allowed”`, return |input|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -234,6 +234,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     type: dfn; text: set the inner text steps; url: set-the-inner-text-steps
     type: dfn; text: src; url: attr-script-src
     type: dfn; text: event handler content attribute; url: event-handler-content-attributes
+    type: dfn; text: configuration; for: Sanitizer; url: configuration
+    type: dfn; text: canonicalize the configuration; url: canonicalize-the-configuration
     type:dictionary; text:Sanitizer
     type:dictionary; text:SanitizerConfig
     type:dictionary; text:SanitizerPresets
@@ -1276,6 +1278,7 @@ To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/g
         Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.
     1. Throw a TypeError and abort further steps.
 1. Let |sanitizer| be |policyValue|["`sanitizer`"], [=with default|defaulting to=] a new {{SanitizerConfig}}.
+1. If |sanitizer| is a {{Sanitizer}}, then set |sanitizer| to a new {{Sanitizer}} whose [=Sanitizer/configuration=] is the result of [=canonicalize the configuration|canonicalizing=] |sanitizer|'s [=Sanitizer/configuration=].
 1. Let |runScripts| be true if |policyValue|["`runScripts`"] is true and |input| is a {{SetHTMLUnsafeOptions}} whose {{SetHTMLUnsafeOptions/runScripts}} is true.
 1. Return a new {{TrustedParserOptions}} in |input|'s [=relevant realm=]
     whose [=TrustedParserOptions/sanitizer=] is set to |sanitizer|,

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1191,6 +1191,8 @@ Inject a sanitizer when using an HTML injection sink.
 </xmp>
 
 Apart from sanizitation, the default policy can also prevent an HTML injection from running scripts.
+HTML inserted with {{SetHTMLUnsafeOptions/runScripts}} set to false can still insert `script` elements into the document,
+but those scripts are not automatically executed.
 
 <xmp highlight=js>
 (function renderFootnote() {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -234,6 +234,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     type: dfn; text: set the inner text steps; url: set-the-inner-text-steps
     type: dfn; text: src; url: attr-script-src
     type: dfn; text: event handler content attribute; url: event-handler-content-attributes
+    type: dfn; text: built-in safe default configuration; url: built-in-safe-default-configuration
     type: dfn; text: configuration; for: Sanitizer; url: configuration
     type: dfn; text: canonicalize the configuration; url: canonicalize-the-configuration
     type:interface; text:Sanitizer
@@ -1409,8 +1410,11 @@ When streaming or in contexts where the HTML string cannot be validated up front
 
 To <dfn>get a sanitizer config from dictionary</dfn> given a dictionary |dictionary|:
 1. Let |sanitizerInput| be |dictionary|["sanitizer"], [=with default|defaulting to=] null.
+1. If |sanitizerInput| is a {{SanitizerPresets}}:
+  1. [=Assert=]: |sanitizerInput| is `"default"`.
+  1. Return the [=built-in safe default configuration=].
 1. If |sanitizerInput| is a {{Sanitizer}}, return a [=map/clone=] of |sanitizerInput|'s [=Sanitizer/configuration=].
-1. If |sanitizerInput| is a {{SanitizerPresets}} or a {{SanitizerConfig}}:
+1. If |sanitizerInput| is a {{SanitizerConfig}}:
     1. Let |sanitizer| be a new {{Sanitizer}}, [=configure|configured=] with |sanitizerInput| and true.
     1. Return a [=map/clone=] of |sanitizer|'s [=Sanitizer/configuration=].
 1. Return null.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -697,7 +697,7 @@ that it's called only with no attacker-controlled values.
 
 While trusted types are built in a way that allows custom sanitizers to be used,
 the {{TrustedTypePolicy/createParserOptions(options)|createParserOptions}} also allows for using them as a way to enforce
-using the built-in sanitizer API. [[SANITIZER-API]]
+using the built-in sanitizer API.
 
 <div class="example" id="trusted-types-with-sanitizer-example">
 <xmp highlight=js>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -571,7 +571,7 @@ The value is set when the object is created, and will never change during its li
 <dfn for="TrustedScriptURL">stringification behavior</dfn> steps of a
 TrustedScriptURL object are to return the associated [=TrustedScriptURL/data=] value.
 
-### <dfn interface>TrustedParserOptions</dfn> ### {#trused-parser-options}
+### <dfn interface>TrustedParserOptions</dfn> ### {#trusted-parser-options}
 
 The {{TrustedParserOptions}} interface represents options that a developer
 can confidently pass into an [=injection sink=] that will parse HTML.
@@ -580,10 +580,9 @@ These objects are immutable wrappers around a
 {{TrustedTypePolicy/createParserOptions(options, ...arguments)|createParserOptions}} method.
 
 <pre class="idl">
-
-[Exposed=(Window)]
+[Exposed=Window]
 interface TrustedParserOptions {
-  Sanitizer? sanitizer();
+  [NewObject] Sanitizer? sanitizer();
   readonly attribute boolean runScripts;
 };
 </pre>
@@ -600,8 +599,8 @@ A {{TrustedParserOptions}} has an associated {{SanitizerConfig}}-or-null
 <div algorithm>
 The <dfn method for="TrustedParserOptions">sanitizer()</dfn> method steps are:
 
-1. If <span>this</span>'s [=TrustedParserOptions/sanitizer config=] is null, return null.
-1. Let |sanitizer| be a new {{Sanitizer}} in <span>this</span>'s [=relevant realm=], whose [=Sanitizer/configuration=] is <span>this</span>'s [=TrustedParserOptions/sanitizer config=].
+1. If [=this=]'s [=TrustedParserOptions/sanitizer config=] is null, return null.
+1. Let |sanitizer| be a new {{Sanitizer}} in [=this=]'s [=relevant realm=], whose [=Sanitizer/configuration=] is a [=map/clone=] of [=this=]'s [=TrustedParserOptions/sanitizer config=].
 1. Return |sanitizer|.
 
 </div>
@@ -693,12 +692,12 @@ access to which can be controlled using JavaScript techniques
 Unsafe no-op policy reachable only from within a single code block to ascertain
 that it's called only with no attacker-controlled values.
 <xmp highlight=js>
-(function renderFootnote() {
+(async function renderFootnote() {
   const unsafePolicy = trustedTypes.createPolicy('html', {
     createHTML: input => input,
   });
-  const footnote = await fetch('/footnote.html').then(r => r.text());
-  footNote.innerHTML = unsafePolicy.createHTML(footnote);
+  const footnoteContent = await fetch('/footnote.html').then(r => r.text());
+  footNote.innerHTML = unsafePolicy.createHTML(footnoteContent);
 })();
 </xmp>
 </div>
@@ -711,9 +710,10 @@ using the built-in sanitizer API.
 
 <div class="example" id="trusted-types-with-sanitizer-example">
 <xmp highlight=js>
-(function renderFootnote() {
-  const footnote = await fetch('/footnote.html').then(r => r.text());
+(async function renderFootnote() {
+  const footnoteContent = await fetch('/footnote.html').then(r => r.text());
   const policy = trustedTypes.createPolicy('html', {
+    createHTML: input => input,
     createParserOptions: options => {
       const sanitizer = new Sanitizer(options.sanitizer || {});
       sanitizer.removeElement("script");
@@ -722,13 +722,16 @@ using the built-in sanitizer API.
       };
     }
   });
-  footNote.setHTMLUnsafe(footnote, policy.createParserOptions({}));
+  footNote.setHTMLUnsafe(footnoteContent, policy.createParserOptions({}));
 })();
 </xmp>
 </div>
 
-Note: `createParserOptions` does not necessarily replace `createHTML`. If both exist in the policy, the `createHTML` function will be called first,
-and the result will be sanitized using the result of the `createParserOptions` function, if that exists.
+Note: `createParserOptions` does not replace `createHTML`. When enforcing Trusted Types,
+any raw string passed to an HTML injection sink must first be converted via `createHTML`.
+If `createParserOptions` also exists in the policy, the result of `createHTML` will then be
+sanitized using the result of `createParserOptions`. Therefore, a policy used for HTML injection sinks
+should define both `createHTML` and `createParserOptions`.
 
 Note: The `sanitizer` option is only supported for HTML documents. If `createParserOptions`
 returns a dictionary with a non-null `sanitizer` value for an XML document, the sink throws
@@ -1170,16 +1173,18 @@ Content-Security-Policy: require-trusted-types-for 'script'
 Inject a sanitizer when using an HTML injection sink.
 
 <xmp highlight=js>
-(function renderFootnote() {
+(async function renderFootnote() {
   const defaultPolicy = trustedTypes.createPolicy('default', {
+    createHTML: string => string,
     createParserOptions: options => {
-      const sanitizer = new Sanitizer(options.sanitizer)
+      const sanitizer = new Sanitizer(options.sanitizer || {});
       sanitizer.removeUnsafe();
       return { ...options, sanitizer };
     }
   });
 
   const trustedOptions = trustedTypes.createPolicy('trusted', {
+    createHTML: string => string,
     createParserOptions: options => options
   }).createParserOptions({});
   const untrustedFootnoteContent = await fetch('/footnote.html').then(r => r.text());
@@ -1199,20 +1204,21 @@ HTML inserted with {{SetHTMLUnsafeOptions/runScripts}} set to false can still in
 but those scripts are not automatically executed.
 
 <xmp highlight=js>
-(function renderFootnote() {
+(async function renderFootnote() {
   const defaultPolicy = trustedTypes.createPolicy('default', {
+    createHTML: string => string,
     createParserOptions: options => {
       return { ...options, runScripts: false };
     }
   });
 
-  // The default policy would override the {{SetHTMLUnsafeOptions/runScripts}} value to false.
+  // The default policy would override the runScripts value to false.
   main.setHTMLUnsafe(someHTMLWithScripts, {runScripts: true});
 
-  // This applies to {{Range/createContextualFragment(string)}}
+  // This applies to Range.prototype.createContextualFragment()
   const fragment = new Range().createContextualFragment("<script>alert(1)</" + "script>");
   const div = document.createElement('div');
-  // The scripts in the fragment would not be executed, as the default policy overrides {{SetHTMLUnsafeOptions/runScripts}}.
+  // The scripts in the fragment would not be executed, as the default policy overrides runScripts.
   div.appendChild(fragment);
 })();
 </xmp>
@@ -1255,13 +1261,11 @@ a string or dictionary |value| and a list |arguments|, perform the following ste
 1.  Let |policyValue| be the result of executing [=get trusted type policy value=] with the same arguments as this algorithm and additionally true as |throwIfMissing|.
 1.  If the algorithm threw an error, rethrow the error and abort the following steps.
 1.  If |trustedTypeName| is `"TrustedParserOptions"`:
-    1.  Let |sanitizer| be null.
-    1.  Let |runScripts| be false.
-    1.  If |policyValue| is a [=dictionary=]:
-        1.  Set |sanitizer| to the result of
-            [=get a sanitizer config from dictionary|getting a sanitizer configuration=]
-            from |policyValue|.
-        1.  Set |runScripts| to |policyValue|["runScripts"] [=with default=] false.
+    1.  If |policyValue| is not a [=dictionary=], throw a {{TypeError}}.
+    1.  Let |sanitizer| be the result of
+        [=get a sanitizer config from dictionary|getting a sanitizer configuration=]
+        from |policyValue|.
+    1.  Let |runScripts| be |policyValue|["runScripts"] [=with default=] false.
     1.  Return a new instance of {{TrustedParserOptions}} in |policy|'s [=relevant realm=] with its
         [=TrustedParserOptions/sanitizer config=] set to |sanitizer|, and its
         [=TrustedParserOptions/runScripts=] set to |runScripts|.
@@ -1311,14 +1315,14 @@ a string or dictionary |value|, a list |arguments|, and a boolean |throwIfMissin
     |args| and `"rethrow"`.
 1.  Return |policyValue|.
 
-## Get Trusted Type parser input ## {#get-trusted-type-parser-input-algorithm}
+## Get Trusted Type compliant input ## {#get-trusted-type-compliant-input-algorithm}
 
-To <dfn export>get Trusted Type compliant input</dfn> given a [=realm/global object=] |global|, a string |input|,
+To <dfn export>get trusted type compliant input</dfn> given a [=realm/global object=] |global|, a string |input|,
 a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, and a string |sink|:
 
-1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing `"TrustedHTML"`, |global|, |input|, |sink|, and `"script"`.
+1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
 1. If the algorithm threw an error, rethrow the error.
-1. Let |compliantOptions| be the result of calling [=get Trusted Type compliant parser options=], passing |global|, |options|, false, and |sink|.
+1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
 1. If the algorithm threw an error, rethrow the error.
 1. Return (|compliantHTML|, |compliantOptions|).
 
@@ -1351,29 +1355,44 @@ To <dfn export>get trusted type compliant string</dfn> a {{TrustedType}} type (|
 
 ## Get Trusted Type compliant parser options ## {#get-trusted-type-compliant-parser-options-algorithm}
 
-To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/global object=] |global|,
+To <dfn export>get trusted type compliant parser options</dfn> given a [=realm/global object=] |global|,
 |input|, which is either a {{TrustedParserOptions}}, a {{SetHTMLUnsafeOptions}}, or a {{ParseHTMLUnsafeOptions}},
 a boolean |throwIfMissing|, and a string |sink|, run these steps:
+
+Note: |throwIfMissing| is false when called alongside [=get trusted type compliant string=] for synchronous injection sinks where the HTML string itself is validated.
+When streaming or in contexts where the HTML string cannot be validated up front, callers pass true for |throwIfMissing| to ensure a default policy with {{TrustedTypePolicyOptions/createParserOptions}} is required.
 
 1.  If |input| is an instance of {{TrustedParserOptions}}, return |input|.
 1.  Let |requireTrustedTypes| be the result of executing [=Does sink type require trusted types?=] algorithm,
     passing |global|, `"script"`, and true.
 1.  If |requireTrustedTypes| is `false`, return |input|.
 1.  Let |defaultPolicy| be the value of |global|'s [=Window/trusted type policy factory=]'s [=TrustedTypePolicyFactory/default policy=].
-1.  If |defaultPolicy| is null, throw a {{TypeError}}.
+1.  If |defaultPolicy| is null:
+    1. If |throwIfMissing| is true:
+        1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
+            passing |global|, |sink|, `"script"`, and the empty string as |source|.
+        1. If |disposition| is `“Allowed”`, return |input|.
+        1. Throw a {{TypeError}}.
+    1. Return |input|.
 1.  Let |function| be |defaultPolicy|'s [=TrustedTypePolicy/options=]["createParserOptions"].
 1.  If |function| is null:
-    1. If |throwIfMissing| is true, throw a {{TypeError}}.
+    1. If |throwIfMissing| is true:
+        1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
+            passing |global|, |sink|, `"script"`, and the empty string as |source|.
+        1. If |disposition| is `“Allowed”`, return |input|.
+        1. Throw a {{TypeError}}.
     1. Return |input|.
 1. Let |runScriptsInput| be |input|["runScripts"], [=with default=] false.
+1. Let |argument| be the [=ordered map=] «[ "runScripts" → |runScriptsInput| ]».
 1. Let |sanitizerInputConfig| be the results of [=get a sanitizer config from dictionary|getting a sanitizer config=] from |input|.
-1. Let |sanitizerInput| be null if |sanitizerInputConfig| is null; otherwise a new {{Sanitizer}}, [=configure|configured=] with |sanitizerInputConfig|.
-1. Let |argument| be the [=ordered map=] «[ "runScripts" → |runScriptsInput|, "sanitizer" → |sanitizerInput| ]».
+1. If |sanitizerInputConfig| is not null:
+    1. Let |sanitizerInput| be a new {{Sanitizer}}, [=configure|configured=] with |sanitizerInputConfig|.
+    1. Set |argument|["sanitizer"] to |sanitizerInput|.
 1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument| » and `"rethrow"`.
 1. If the algorithm threw an error, rethrow the error and abort the following steps.
 1. If |policyValue| is `null` or `undefined`:
     1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
-        passing |global|, |sink|, `"script"`, and stringified |input| as |source|.
+        passing |global|, |sink|, `"script"`, and the empty string as |source|.
     1. If |disposition| is `“Allowed”`, return |input|.
 
         Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.
@@ -1388,9 +1407,11 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
 
 To <dfn>get a sanitizer config from dictionary</dfn> given a dictionary |dictionary|:
 1. Let |sanitizerInput| be |dictionary|["sanitizer"], [=with default|defaulting to=] null.
-1. If |sanitizerInput| is a {{Sanitizer}}, set it to |sanitizerInput|'s
-    [=Sanitizer/configuration=].
-1. Return |sanitizerInput|.
+1. If |sanitizerInput| is a {{Sanitizer}}, return a [=map/clone=] of |sanitizerInput|'s [=Sanitizer/configuration=].
+1. If |sanitizerInput| is a {{SanitizerPresets}} or a {{SanitizerConfig}}:
+    1. Let |sanitizer| be a new {{Sanitizer}}, [=configure|configured=] with |sanitizerInput|.
+    1. Return a [=map/clone=] of |sanitizer|'s [=Sanitizer/configuration=].
+1. Return null.
 
 
 ## Process value with a default policy ## {#process-value-with-a-default-policy-algorithm}
@@ -1440,7 +1461,7 @@ To <dfn export>get trusted type compliant attribute value</dfn> given a string |
     * |attributeNs|
 1. If |attributeData| is null, then:
     1. If |newValue| is a string, return |newValue|.
-    1. <a>Assert</a>: |newValue| is {{TrustedHTML}} or {{TrustedScript}} or {{TrustedScriptURL}} or {{TrustedParserOptions}}.
+    1. <a>Assert</a>: |newValue| is {{TrustedHTML}} or {{TrustedScript}} or {{TrustedScriptURL}}.
     1. Return |value|'s associated data.
 1. Let |expectedType| be the value of the fourth member of |attributeData|.
 1. Let |sink| be the value of the fifth member of |attributeData|.
@@ -1453,7 +1474,7 @@ To <dfn export>get trusted type compliant attribute value</dfn> given a string |
 
    If the algorithm threw an error, rethrow the error.
 
-## Get Trusted Type data for attribute ## {#get-trusted-type-data-for-attribute-algorithm}
+## Get Trusted Type data for attribute ## {#get-trusted-type-data-for-attribute}
 
 To <dfn>get Trusted Type data for attribute</dfn> given |element|, |attribute|, |attributeNs|, perform the following steps:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -733,8 +733,6 @@ without requiring {{TrustedTypePolicyOptions/createHTML}} or a {{TrustedHTML}} i
 (such as {{HTMLIFrameElement/srcdoc}} or `document.write()`), raw strings must still be converted via {{TrustedTypePolicyOptions/createHTML}}.
 
 Note: When used in legacy HTML injection sinks such as {{Element/innerHTML}}, the `sanitizer` option is only supported for HTML documents.
-If `createParserOptions` returns a dictionary with a non-null `sanitizer` value for a legacy sink in an XML document, the sink throws a {{TypeError}}
-(unless Content Security Policy is configured in report-only mode, in which case the violation is reported without throwing).
 When protecting XML documents using legacy sinks, authors are advised to use `createHTML` instead.
 
 ### <dfn interface>TrustedTypePolicyFactory</dfn> ### {#trusted-type-policy-factory}
@@ -1425,6 +1423,7 @@ To <dfn>get a sanitizer config copy from dictionary</dfn> given a [=realm=] |rea
     1. Set |configuration| to |sanitizerInput|'s [=Sanitizer/configuration=].
 1. Otherwise, if |sanitizerInput| is a {{SanitizerConfig}}:
     1. Set |configuration| to |sanitizerInput|.
+1. [=Assert=]: |configuration| is not null.
 1. Let |sanitizer| be a new {{Sanitizer}} in |realm|.
 1. [=configure a sanitizer|Configure=] |sanitizer| given |configuration| and true.
 1. Return |sanitizer|'s [=Sanitizer/configuration=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -236,7 +236,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     type: dfn; text: event handler content attribute; url: event-handler-content-attributes
     type: dfn; text: built-in safe default configuration; url: built-in-safe-default-configuration
     type: dfn; text: configuration; for: Sanitizer; url: configuration
-    type: dfn; text: configure; for: Sanitizer; url: configure-a-sanitizer
     type: dfn; text: configure a sanitizer; url: configure-a-sanitizer
     type: dfn; text: canonicalize the configuration; url: canonicalize-the-configuration
     type: dfn; text: valid; for: SanitizerConfig; url: dom-sanitizerconfig-valid
@@ -1315,7 +1314,7 @@ a string or dictionary |value|, a list |arguments|, and a boolean |throwIfMissin
 ## Get Trusted Type compliant input ## {#get-trusted-type-compliant-input-algorithm}
 
 To <dfn export>get trusted type compliant input</dfn> given a [=realm/global object=] |global|, a string or {{TrustedHTML}} |input|,
-a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, and a string |sink|, and an optional boolean |isXMLDocument| (default false):
+a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, a string |sink|, and an optional `"html"` or `"xml"` |documentType| (default `"html"`):
 
 1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
 1. If the algorithm threw an error, rethrow the error.
@@ -1326,7 +1325,7 @@ a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions
     1. Return (stringified |input|, |trustedOptions|).
 1. If |options| is an instance of {{TrustedParserOptions}}, return (stringified |input|, |compliantOptions|).
 1. If |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer config=] is not null:
-    1. If |isXMLDocument| is true:
+    1. If |documentType| is `"xml"`:
         1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
             passing |global|, |sink|, `"script"`, and stringified |input| as |source|.
         1. If |disposition| is "Blocked", throw a {{TypeError}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -599,6 +599,7 @@ The <dfn method for="TrustedParserOptions">sanitizer()</dfn> method steps are:
 1. If [=this=]'s [=TrustedParserOptions/sanitizer config=] is null, return null.
 1. Let |sanitizer| be a new {{Sanitizer}} in [=this=]'s [=relevant realm=], [=configure|configured=] with [=this=]'s [=TrustedParserOptions/sanitizer config=] and true.
 1. Return |sanitizer|.
+
 </div>
 
 ## <dfn>Policies</dfn> ## {#policies-hdr}
@@ -1478,7 +1479,7 @@ To <dfn export>get trusted type compliant attribute value</dfn> given a string |
 
    If the algorithm threw an error, rethrow the error.
 
-## Get Trusted Type data for attribute ## {#get-trusted-type-data-for-attribute}
+## Get Trusted Type data for attribute ## {#get-trusted-type-data-for-attribute-algo}
 
 To <dfn>get Trusted Type data for attribute</dfn> given |element|, |attribute|, |attributeNs|, perform the following steps:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -236,6 +236,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     type: dfn; text: event handler content attribute; url: event-handler-content-attributes
     type: dfn; text: built-in safe default configuration; url: built-in-safe-default-configuration
     type: dfn; text: configuration; for: Sanitizer; url: configuration
+    type: dfn; text: canonicalize the configuration; url: canonicalize-the-configuration
+    type: dfn; text: valid; for: SanitizerConfig; url: dom-sanitizerconfig-valid
     type:interface; text:Sanitizer
     type:dictionary; text:SanitizerConfig
     type:enum; text:SanitizerPresets
@@ -597,7 +599,8 @@ The {{TrustedParserOptions/runScripts}} getter steps are to return [=this=]'s as
 The <dfn method for="TrustedParserOptions">sanitizer()</dfn> method steps are:
 
 1. If [=this=]'s [=TrustedParserOptions/sanitizer config=] is null, return null.
-1. Let |sanitizer| be a new {{Sanitizer}} in [=this=]'s [=relevant realm=], [=configure|configured=] with [=this=]'s [=TrustedParserOptions/sanitizer config=] and true.
+1. Let |config| be the result of [=map/clone|cloning=] [=this=]'s [=TrustedParserOptions/sanitizer config=].
+1. Let |sanitizer| be a new {{Sanitizer}} in [=this=]'s [=relevant realm=], [=configure|configured=] with |config| and true.
 1. Return |sanitizer|.
 
 </div>
@@ -1219,8 +1222,6 @@ but those scripts are not automatically executed.
 
 </div>
 
-
-
 # Algorithms # {#algorithms}
 
 ## Create a Trusted Type Policy ## {#create-trusted-type-policy-algorithm}
@@ -1321,7 +1322,9 @@ a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions
     1. Let |sanitizerConfig| be |options|'s [=TrustedParserOptions/sanitizer config=] if |options| is an instance of {{TrustedParserOptions}}; otherwise the result of [=get a sanitizer config from dictionary|getting a sanitizer configuration=] from |options|.
     1. Let |trustedOptions| be a new {{TrustedParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedParserOptions/sanitizer config=] is |sanitizerConfig| and whose [=TrustedParserOptions/runScripts=] is |runScripts|.
     1. Return (stringified |input|, |trustedOptions|).
-1. If |compliantOptions| is an instance of {{TrustedParserOptions}}, return (stringified |input|, |compliantOptions|).
+1. If |options| is an instance of {{TrustedParserOptions}}, return (stringified |input|, |compliantOptions|).
+1. If |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer config=] is not null:
+    1. Return (stringified |input|, |compliantOptions|).
 1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
 1. If the algorithm threw an error, rethrow the error.
 1. Return (|compliantHTML|, |compliantOptions|).
@@ -1416,8 +1419,13 @@ To <dfn>get a sanitizer config from dictionary</dfn> given a dictionary |diction
     1. Set |config| to |sanitizerInput|.
 1. Otherwise:
     1. Return null.
-1. Let |sanitizer| be a new {{Sanitizer}}, [=configure|configured=] with |config| and true.
-1. Return |sanitizer|'s [=Sanitizer/configuration=].
+1. Set |config| to a [=map/clone=] of |config|.
+1. [=canonicalize the configuration|Canonicalize the configuration=] |config| with true.
+1. If |config| is not [=SanitizerConfig/valid=], then throw a {{TypeError}}.
+
+    Note: This creates a fresh copy of each list, leaving the original |config| immutable.
+
+1. Return |config|.
 
 ## Process value with a default policy ## {#process-value-with-a-default-policy-algorithm}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1248,17 +1248,17 @@ a string |value| and a list |arguments|, perform the following steps:
 
 1.  Let |policyValue| be the result of executing [=get trusted type policy value=] with the same arguments as this algorithm and additionally true as |throwIfMissing|.
 1.  If the algorithm threw an error, rethrow the error and abort the following steps.
-1. If |trustedTypeName| is "TrustedParserOptions":
-    1. Let |sanitizer| be a new {{SanitizerConfig}}.
-    1. Let |runScripts| be false.
-    1. If |policyValue| is a [=dictionary=]:
-        1. Set |sanitizer| to the result of
+1.  If |trustedTypeName| is `"TrustedParserOptions"`:
+    1.  Let |sanitizer| be a new {{SanitizerConfig}}.
+    1.  Let |runScripts| be false.
+    1.  If |policyValue| is a [=dictionary=]:
+        1.  Set |sanitizer| to the result of
             [=get a sanitizer configuration from dictionary|getting a sanitizer configuration=]
             from |policyValue|.
-        1. Set |runScripts| to |policyValue|["runScripts"] [=with default=] false.
-  1. Return a new instance of {{TrustedParserOptions}} with its
-      [=TrustedParserOptions/sanitizer=] set to |sanitizer|, and its
-      [=TrustedParserOptions/runScripts=] set to |runScripts|.
+        1.  Set |runScripts| to |policyValue|["runScripts"] [=with default=] false.
+    1.  Return a new instance of {{TrustedParserOptions}} with its
+        [=TrustedParserOptions/sanitizer=] set to |sanitizer|, and its
+        [=TrustedParserOptions/runScripts=] set to |runScripts|.
 1.  Let |dataString| be the result of stringifying |policyValue|.
 1.  If |policyValue| is null or undefined, set |dataString| to the empty string.
 1.  Return a new instance of an interface with a type

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1222,6 +1222,20 @@ a string |value|, a list |arguments|, and a boolean |throwIfMissing|, perform th
     |args| and `"rethrow"`.
 1.  Return |policyValue|.
 
+## Get Trusted Type parser input ## {#get-trusted-type-parser-input-algorithm}
+
+To <dfn export>get Trusted Type compliant input</dfn> given a {{TrustedType}} |expectedType|, a [=realm/global object=] (|global|), string, or <code data-x="">Stream</code> |input|,
+a {{TrustedParserOptions}}, {{SetHTMLUnsafeOptions}} or <code data-x="">Legacy</code> |options|, a string (|sink|) and a string (|sinkGroup|), run these steps:
+
+1. If |input| is not a <code data-x="">Stream</code>:
+  1. Set |input| to the result of calling get trusted type compliant string, passing |expectedType|, |global|, |input|, |sink| and |sinkGroup|.
+  1. If the algorithm threw an error, rethrow the error and abort the following steps.
+1. If |options| is <code data-x="">Legacy</code>, set |options| to a new {{SetHTMLUnsafeOptions}} dictionary.
+1. Let |throwIfMissing| be true if |input| is not a <code data-x="">Stream</code>; Otherwise false.
+1. Set |options| to the result of calling [=get Trusted Type compliant parser options=], passing |global|, |options|, |throwIfMissing|, |sink|, and |sinkGroup|.
+1. If the algorithm threw an error, rethrow the error and abort the following steps.
+1. Return (|input|, |options|).
+
 ## Get Trusted Type compliant string ## {#get-trusted-type-compliant-string-algorithm}
 
 This algorithm will return a string that can be used with an
@@ -1252,7 +1266,7 @@ To <dfn export>get trusted type compliant string</dfn> a {{TrustedType}} type (|
 ## Get Trusted Type compliant parser options ## {#get-trusted-type-compliant-parser-options-algorithm}
 
 To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/global object=] (|global|),
-{{TrustedParserOptions}} or a {{SetHTMLOptions}} or a {{SetHTMLUnsafeOptions}} (|input|), a boolean |throwIfMissing|, a string (|sink|) and a string (|sinkGroup|), run these steps:
+{{TrustedParserOptions}} or a {{SetHTMLUnsafeOptions}} |input|, a boolean |throwIfMissing|, a string |sink| and a string |sinkGroup|, run these steps:
 
 1.  If |input| is an instance of {{TrustedParserOptions}}, return |input|.
 1.  Let |requireTrustedTypes| be the result of executing [=Does sink type require trusted types?=] algorithm,
@@ -1276,9 +1290,13 @@ To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/g
     1. If |disposition| is `“Allowed”`, return |input| and abort further steps.
 
         Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.
+
     1. Throw a TypeError and abort further steps.
 1. Let |sanitizer| be |policyValue|["`sanitizer`"], [=with default|defaulting to=] a new {{SanitizerConfig}}.
-1. If |sanitizer| is a {{Sanitizer}}, then set |sanitizer| to a new {{Sanitizer}} whose [=Sanitizer/configuration=] is the result of [=canonicalize the configuration|canonicalizing=] |sanitizer|'s [=Sanitizer/configuration=].
+1. If |sanitizer| is a {{Sanitizer}}, then set |sanitizer| to a new {{Sanitizer}} whose [=Sanitizer/configuration=] is the result of [=canonicali`ze the configuration|canonicalizing=] |sanitizer|'s [=Sanitizer/configuration=].
+
+  This step assures that the provided {{Sanitizer}} is not mutated by the policy.
+
 1. Let |runScripts| be true if |policyValue|["`runScripts`"] is true and |input| is a {{SetHTMLUnsafeOptions}} whose {{SetHTMLUnsafeOptions/runScripts}} is true.
 1. Return a new {{TrustedParserOptions}} in |input|'s [=relevant realm=]
     whose [=TrustedParserOptions/sanitizer=] is set to |sanitizer|,

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -601,9 +601,9 @@ A {{TrustedParserOptions}} has an associated {{SanitizerConfig}}
 <div algorithm>
 The <dfn method for="TrustedParserOptions">sanitizer()</dfn> method steps are:
 
-1. Let |sanitizer| be a new {{Sanitizer}} in <span>this</span>'s [=relevant realm=].
-2. [=configure|Configure=] |sanitizer| with <span>this</span>'s [=TrustedParserOptions/sanitizer=] and true.
-3. Return |sanitizer|.
+1. Let |sanitizer| be a new {{Sanitizer}} in <span>this</span>'s [=relevant realm=], whose [=Sanitizer/configuration=] is <span>this</span>'s [=TrustedParserOptions/sanitizer=].
+2. Return |sanitizer|.
+
 </div>
 
 ## <dfn>Policies</dfn> ## {#policies-hdr}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1360,7 +1360,7 @@ To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/g
 
         Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.
 
-    1. Throw a TypeError and abort further steps.
+    1. Throw a {{TypeError}}.
 1. Let |sanitizer| be |policyValue|["`sanitizer`"], [=with default|defaulting to=] a new {{SanitizerConfig}}.
 1. If |sanitizer| is a {{Sanitizer}}, then set |sanitizer| to a new {{Sanitizer}} whose [=Sanitizer/configuration=] is the result of [=canonicalize the configuration|canonicalizing=] |sanitizer|'s [=Sanitizer/configuration=].
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1317,7 +1317,7 @@ a string or dictionary |value|, a list |arguments|, and a boolean |throwIfMissin
 
 ## Get Trusted Type compliant input ## {#get-trusted-type-compliant-input-algorithm}
 
-To <dfn export>get trusted type compliant input</dfn> given a [=realm/global object=] |global|, a string |input|,
+To <dfn export>get trusted type compliant input</dfn> given a [=realm/global object=] |global|, a string or {{TrustedHTML}} |input|,
 a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, and a string |sink|:
 
 1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -971,7 +971,7 @@ interface TrustedTypePolicy {
   TrustedHTML createHTML(DOMString input, any... arguments);
   TrustedScript createScript(DOMString input, any... arguments);
   TrustedScriptURL createScriptURL(DOMString input, any... arguments);
-  TrustedParserOptions createParserOptions(SetHTMLUnsafeOptions options, any... arguments);
+  [Exposed=Window] TrustedParserOptions createParserOptions(SetHTMLUnsafeOptions options, any... arguments);
 };
 </pre>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1320,14 +1320,8 @@ a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions
 1. If the algorithm threw an error, rethrow the error.
 1. If |input| is an instance of {{TrustedHTML}}:
     1. Return (stringified |input|, |compliantOptions|).
-1. Let |isSanitizedByParser| be true if |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer config=] is not null; otherwise false.
-1. If |isSanitizedByParser| is true:
-    1. Let |defaultPolicy| be the value of |global|'s [=Window/trusted type policy factory=]'s [=TrustedTypePolicyFactory/default policy=].
-    2. If |defaultPolicy| is not null and |defaultPolicy|'s [=TrustedTypePolicy/options=]["createHTML"] is not null:
-        1. Let |transformedInput| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
-        2. If the algorithm threw an error, rethrow the error.
-        3. Return (|transformedInput|, |compliantOptions|).
-    3. Return (stringified |input|, |compliantOptions|).
+1. If |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer config=] is not null:
+    1. Return (stringified |input|, |compliantOptions|).
 1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
 1. If the algorithm threw an error, rethrow the error.
 1. Return (|compliantHTML|, |compliantOptions|).

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1317,7 +1317,7 @@ a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions
 1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
 1. If the algorithm threw an error, rethrow the error.
 1. If |input| is an instance of {{TrustedHTML}}:
-    1. Let |runScripts| be true if |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/runScripts=] is true; otherwise |compliantOptions| |compliantOptions|["runScripts"] [=with default=] false.
+    1. Let |runScripts| be |compliantOptions|'s [=TrustedParserOptions/runScripts=] if |compliantOptions| is an instance of {{TrustedParserOptions}}; otherwise |compliantOptions|["runScripts"], [=with default=] false.
     1. Let |sanitizerConfig| be |options|'s [=TrustedParserOptions/sanitizer config=] if |options| is an instance of {{TrustedParserOptions}}; otherwise the result of [=get a sanitizer config from dictionary|getting a sanitizer configuration=] from |options|.
     1. Let |trustedOptions| be a new {{TrustedParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedParserOptions/sanitizer config=] is |sanitizerConfig| and whose [=TrustedParserOptions/runScripts=] is |runScripts|.
     1. Return (stringified |input|, |trustedOptions|).

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -236,11 +236,9 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     type: dfn; text: event handler content attribute; url: event-handler-content-attributes
     type: dfn; text: built-in safe default configuration; url: built-in-safe-default-configuration
     type: dfn; text: configuration; for: Sanitizer; url: configuration
-    type: dfn; text: canonicalize the configuration; url: canonicalize-the-configuration
     type:interface; text:Sanitizer
     type:dictionary; text:SanitizerConfig
     type:enum; text:SanitizerPresets
-    type:dictionary; text:SetHTMLOptions
     type:dictionary; text:SetHTMLUnsafeOptions
 spec:DOM; urlPrefix: https://dom.spec.whatwg.org/
     type: dfn; text: get text content; url: get-text-content
@@ -588,22 +586,19 @@ interface TrustedParserOptions {
 };
 </pre>
 
-{{TrustedParserOptions}} objects have an associated boolean <dfn export for="TrustedParserOptions">runScripts</dfn>.
+{{TrustedParserOptions}} objects have an associated boolean <dfn export for="TrustedParserOptions">runScripts</dfn>
+and an associated {{SanitizerConfig}}-or-null <dfn export for="TrustedParserOptions">sanitizer config</dfn>.
 These values are set when the object is created, and will never change during its lifetime.
 
 The {{TrustedParserOptions/runScripts}} getter steps are to return [=this=]'s associated
 [=TrustedParserOptions/runScripts=].
 
-A {{TrustedParserOptions}} has an associated {{SanitizerConfig}}-or-null
-<dfn export for="TrustedParserOptions">sanitizer config</dfn>.
-
 <div algorithm>
 The <dfn method for="TrustedParserOptions">sanitizer()</dfn> method steps are:
 
 1. If [=this=]'s [=TrustedParserOptions/sanitizer config=] is null, return null.
-1. Let |sanitizer| be a new {{Sanitizer}} in [=this=]'s [=relevant realm=], whose [=Sanitizer/configuration=] is a [=map/clone=] of [=this=]'s [=TrustedParserOptions/sanitizer config=].
+1. Let |sanitizer| be a new {{Sanitizer}} in [=this=]'s [=relevant realm=], [=configure|configured=] with [=this=]'s [=TrustedParserOptions/sanitizer config=] and true.
 1. Return |sanitizer|.
-
 </div>
 
 ## <dfn>Policies</dfn> ## {#policies-hdr}
@@ -706,7 +701,7 @@ that it's called only with no attacker-controlled values.
 ### Using together with a sanitizer ### {#trusted-types-with-sanitizer}
 
 While trusted types are built in a way that allows custom sanitizers to be used,
-the {{TrustedTypePolicy/createParserOptions(options)|createParserOptions}} also allows for using them as a way to enforce
+the {{TrustedTypePolicy/createParserOptions(options, ...arguments)|createParserOptions}} also allows for using them as a way to enforce
 using the built-in sanitizer API.
 
 <div class="example" id="trusted-types-with-sanitizer-example">
@@ -715,7 +710,7 @@ using the built-in sanitizer API.
   const footnoteContent = await fetch('/footnote.html').then(r => r.text());
   const policy = trustedTypes.createPolicy('html', {
     createParserOptions: options => {
-      const sanitizer = new Sanitizer(options.sanitizer || {});
+      const sanitizer = new Sanitizer(options.sanitizer?.get() ?? {});
       sanitizer.removeElement("script");
       return {
         sanitizer,
@@ -733,7 +728,8 @@ without requiring {{TrustedTypePolicyOptions/createHTML}} or a {{TrustedHTML}} i
 (such as {{HTMLIFrameElement/srcdoc}} or `document.write()`), raw strings must still be converted via {{TrustedTypePolicyOptions/createHTML}}.
 
 Note: When used in legacy HTML injection sinks such as {{Element/innerHTML}}, the `sanitizer` option is only supported for HTML documents.
-If `createParserOptions` returns a dictionary with a non-null `sanitizer` value for a legacy sink in an XML document, the sink throws a {{TypeError}}.
+If `createParserOptions` returns a dictionary with a non-null `sanitizer` value for a legacy sink in an XML document, the sink throws a {{TypeError}}
+(unless Content Security Policy is configured in report-only mode, in which case the violation is reported without throwing).
 When protecting XML documents using legacy sinks, authors are advised to use `createHTML` instead.
 
 ### <dfn interface>TrustedTypePolicyFactory</dfn> ### {#trusted-type-policy-factory}
@@ -977,7 +973,7 @@ interface TrustedTypePolicy {
   TrustedHTML createHTML(DOMString input, any... arguments);
   TrustedScript createScript(DOMString input, any... arguments);
   TrustedScriptURL createScriptURL(DOMString input, any... arguments);
-  [Exposed=Window] TrustedParserOptions createParserOptions(SetHTMLUnsafeOptions options, any... arguments);
+  [Exposed=Window] TrustedParserOptions createParserOptions(optional SetHTMLUnsafeOptions options = {}, any... arguments);
 };
 </pre>
 
@@ -1067,7 +1063,7 @@ dictionary TrustedTypePolicyOptions {
 callback CreateHTMLCallback = DOMString? (DOMString input, any... arguments);
 callback CreateScriptCallback = DOMString? (DOMString input, any... arguments);
 callback CreateScriptURLCallback = USVString? (DOMString input, any... arguments);
-callback CreateParserOptionsCallback = SetHTMLUnsafeOptions? (SetHTMLUnsafeOptions options, any... arguments);
+callback CreateParserOptionsCallback = SetHTMLUnsafeOptions? (optional SetHTMLUnsafeOptions options = {}, any... arguments);
 </pre>
 
 ### <dfn data-lt="default-policy-explanation">Default policy</dfn> ### {#default-policy-hdr}
@@ -1154,12 +1150,12 @@ via using the <a http-header>Content-Security-Policy-Report-Only</a> HTTP Respon
 Note: Most of the enforcement rules are defined as modifications of the
 algorithms in other specifications, see [[#integrations]].
 
-### Sanitization enforcement with {{TrustedTypePolicy/createParserOptions(options)|createParserOptions}} ### {#sanitization-enforcement-hdr}
+### Sanitization enforcement with {{TrustedTypePolicy/createParserOptions(options, ...arguments)|createParserOptions}} ### {#sanitization-enforcement-hdr}
 
 While {{TrustedTypePolicyOptions/createHTML|createHTML}} relies on sanitizing strings before they are injected to the parser using a JS sanitizer,
-the {{TrustedTypePolicy/createParserOptions(options)|createParserOptions}} allows the page's default policy to enforce HTML sanitization.
+the {{TrustedTypePolicy/createParserOptions(options, ...arguments)|createParserOptions}} allows the page's default policy to enforce HTML sanitization.
 
-A {{TrustedTypePolicy/createParserOptions(options)|createParserOptions}} callback in a required default policy would run for
+A {{TrustedTypePolicy/createParserOptions(options, ...arguments)|createParserOptions}} callback in a required default policy would run for
 any attempt to inject HTML into a document using script.
 
 <div class="example" id="require-sanitizer-for-html-injection">
@@ -1173,9 +1169,9 @@ Inject a sanitizer when using an HTML injection sink.
 
 <xmp highlight=js>
 (async function renderFootnote() {
-  const defaultPolicy = trustedTypes.createPolicy('default', {
+  trustedTypes.createPolicy('default', {
     createParserOptions: options => {
-      const sanitizer = new Sanitizer(options.sanitizer || {});
+      const sanitizer = new Sanitizer(options.sanitizer?.get() ?? {});
       sanitizer.removeUnsafe();
       return { ...options, sanitizer };
     }
@@ -1202,7 +1198,7 @@ but those scripts are not automatically executed.
 
 <xmp highlight=js>
 (async function renderFootnote() {
-  const defaultPolicy = trustedTypes.createPolicy('default', {
+  trustedTypes.createPolicy('default', {
     createHTML: string => string,
     createParserOptions: options => {
       return { ...options, runScripts: false };
@@ -1320,11 +1316,11 @@ a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions
 1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
 1. If the algorithm threw an error, rethrow the error.
 1. If |input| is an instance of {{TrustedHTML}}:
-    1. Let |runScripts| be true if |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/runScripts=] is true, or if |compliantOptions| is a dictionary and |compliantOptions|["runScripts"], [=with default=] false is true; otherwise false.
-    1. Let |trustedOptions| be a new {{TrustedParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedParserOptions/sanitizer config=] is null and whose [=TrustedParserOptions/runScripts=] is |runScripts|.
+    1. Let |runScripts| be true if |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/runScripts=] is true; otherwise |compliantOptions| |compliantOptions|["runScripts"] [=with default=] false.
+    1. Let |sanitizerConfig| be |options|'s [=TrustedParserOptions/sanitizer config=] if |options| is an instance of {{TrustedParserOptions}}; otherwise the result of [=get a sanitizer config from dictionary|getting a sanitizer configuration=] from |options|.
+    1. Let |trustedOptions| be a new {{TrustedParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedParserOptions/sanitizer config=] is |sanitizerConfig| and whose [=TrustedParserOptions/runScripts=] is |runScripts|.
     1. Return (stringified |input|, |trustedOptions|).
-1. If |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer config=] is not null:
-    1. Return (stringified |input|, |compliantOptions|).
+1. If |compliantOptions| is an instance of {{TrustedParserOptions}}, return (stringified |input|, |compliantOptions|).
 1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
 1. If the algorithm threw an error, rethrow the error.
 1. Return (|compliantHTML|, |compliantOptions|).
@@ -1355,15 +1351,14 @@ To <dfn export>get trusted type compliant string</dfn> a {{TrustedType}} type (|
 1. Assert: |convertedInput| is an instance of |expectedType|.
 1. Return stringified |convertedInput|.
 
-
 ## Get Trusted Type compliant parser options ## {#get-trusted-type-compliant-parser-options-algorithm}
+
+Note: |throwIfMissing| is false when called from [=get trusted type compliant input=]. For synchronous fragment injection sinks, a valid sanitizer configuration in the resulting options can satisfy Trusted Types enforcement without requiring {{TrustedTypePolicyOptions/createHTML}} on the input string.
+When streaming or in contexts where the HTML string cannot be validated up front, callers pass true for |throwIfMissing| to ensure a default policy with {{TrustedTypePolicyOptions/createParserOptions}} is required.
 
 To <dfn export>get trusted type compliant parser options</dfn> given a [=realm/global object=] |global|,
 |input|, which is either a {{TrustedParserOptions}}, a {{SetHTMLUnsafeOptions}}, or a {{ParseHTMLUnsafeOptions}},
 a boolean |throwIfMissing|, and a string |sink|, run these steps:
-
-Note: |throwIfMissing| is false when called from [=get trusted type compliant input=]. For synchronous fragment injection sinks, a valid sanitizer configuration in the resulting options can satisfy Trusted Types enforcement without requiring {{TrustedTypePolicyOptions/createHTML}} on the input string.
-When streaming or in contexts where the HTML string cannot be validated up front, callers pass true for |throwIfMissing| to ensure a default policy with {{TrustedTypePolicyOptions/createParserOptions}} is required.
 
 1.  If |input| is an instance of {{TrustedParserOptions}}, return |input|.
 1.  Let |requireTrustedTypes| be the result of executing [=Does sink type require trusted types?=] algorithm,
@@ -1389,9 +1384,9 @@ When streaming or in contexts where the HTML string cannot be validated up front
 1. Let |argument| be the [=ordered map=] «[ "runScripts" → |runScriptsInput| ]».
 1. Let |sanitizerInputConfig| be the results of [=get a sanitizer config from dictionary|getting a sanitizer config=] from |input|.
 1. If |sanitizerInputConfig| is not null:
-    1. Let |sanitizerInput| be a new {{Sanitizer}}, [=configure|configured=] with |sanitizerInputConfig| and true.
+    1. Let |sanitizerInput| be a new {{Sanitizer}} in |global|'s [=relevant realm=], [=configure|configured=] with |sanitizerInputConfig| and true.
     1. Set |argument|["sanitizer"] to |sanitizerInput|.
-1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument| » and `"rethrow"`.
+1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument|, |sink| » and `"rethrow"`.
 1. If the algorithm threw an error, rethrow the error and abort the following steps.
 1. If |policyValue| is `null` or `undefined`:
     1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
@@ -1410,15 +1405,18 @@ When streaming or in contexts where the HTML string cannot be validated up front
 
 To <dfn>get a sanitizer config from dictionary</dfn> given a dictionary |dictionary|:
 1. Let |sanitizerInput| be |dictionary|["sanitizer"], [=with default|defaulting to=] null.
+1. Let |config| be null.
 1. If |sanitizerInput| is a {{SanitizerPresets}}:
-  1. [=Assert=]: |sanitizerInput| is `"default"`.
-  1. Return the [=built-in safe default configuration=].
-1. If |sanitizerInput| is a {{Sanitizer}}, return a [=map/clone=] of |sanitizerInput|'s [=Sanitizer/configuration=].
-1. If |sanitizerInput| is a {{SanitizerConfig}}:
-    1. Let |sanitizer| be a new {{Sanitizer}}, [=configure|configured=] with |sanitizerInput| and true.
-    1. Return a [=map/clone=] of |sanitizer|'s [=Sanitizer/configuration=].
-1. Return null.
-
+    1. [=Assert=]: |sanitizerInput| is `"default"`.
+    1. Set |config| to the [=built-in safe default configuration=].
+1. Otherwise if |sanitizerInput| is a {{Sanitizer}}:
+    1. Set |config| to |sanitizerInput|'s [=Sanitizer/configuration=].
+1. Otherwise if |sanitizerInput| is a {{SanitizerConfig}}:
+    1. Set |config| to |sanitizerInput|.
+1. Otherwise:
+    1. Return null.
+1. Let |sanitizer| be a new {{Sanitizer}}, [=configure|configured=] with |config| and true.
+1. Return |sanitizer|'s [=Sanitizer/configuration=].
 
 ## Process value with a default policy ## {#process-value-with-a-default-policy-algorithm}
 
@@ -1813,7 +1811,7 @@ The <dfn export>does sink type require trusted types?</dfn> algorithm, given a [
 
 This algorithm returns `"Blocked"` if the [=injection sink=] requires a [=Trusted Type=], and `"Allowed"` otherwise.
 
-The <dfn>should sink type mismatch violation be blocked by content security policy?</dfn> algorithm, given a [=realm/global object=] (|global|), a string (|sink|), a string (|sinkGroup|) and a string (|source|), performs the following steps:
+The <dfn export>should sink type mismatch violation be blocked by content security policy?</dfn> algorithm, given a [=realm/global object=] (|global|), a string (|sink|), a string (|sinkGroup|) and a string (|source|), performs the following steps:
 
 1.  Let |result| be `"Allowed"`.
 1.  Let |sample| be |source|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1356,7 +1356,7 @@ To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/g
 1. If |policyValue| is `null` or `undefined`, execute the following steps:
     1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
         passing |global|, |input|, |sinkGroup| and |sink|.
-    1. If |disposition| is `“Allowed”`, return |input| and abort further steps.
+    1. If |disposition| is `“Allowed”`, return |input|.
 
         Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1315,7 +1315,7 @@ a string |value|, a list |arguments|, and a boolean |throwIfMissing|, perform th
 ## Get Trusted Type parser input ## {#get-trusted-type-parser-input-algorithm}
 
 To <dfn export>get Trusted Type compliant input</dfn> given a [=realm/global object=] |global|, a string |input|,
-a {{TrustedParserOptions}} or {{SetHTMLUnsafeOptions}} |options|, and a string |sink|:
+a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, and a string |sink|:
 
 1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing `"TrustedHTML"`, |global|, |input|, |sink|, and `"script"`.
 1. If the algorithm threw an error, rethrow the error.
@@ -1381,7 +1381,7 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
 
     1. Throw a {{TypeError}}.
 1. Let |runScripts| be true if |policyValue|["`runScripts`"] is true and |input| is a {{SetHTMLUnsafeOptions}} whose {{SetHTMLUnsafeOptions/runScripts}} is true.
-1. Return a new {{TrustedParserOptions}} in |input|'s [=relevant realm=]
+1. Return a new {{TrustedParserOptions}} in |global|'s [=relevant realm=]
     whose [=TrustedParserOptions/sanitizer config=] is set to the result of
     [=get a sanitizer config from dictionary|getting a sanitizer configuration=] from
     |policyValue|,

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -584,7 +584,7 @@ These objects are immutable wrappers around a
 
 [Exposed=(Window)]
 interface TrustedParserOptions {
-  Sanitizer sanitizer();
+  Sanitizer? sanitizer();
   readonly attribute boolean runScripts;
 };
 </pre>
@@ -595,14 +595,15 @@ These values are set when the object is created, and will never change during it
 The {{TrustedParserOptions/runScripts}} getter steps are to return [=this=]'s associated
 [=TrustedParserOptions/runScripts=].
 
-A {{TrustedParserOptions}} has an associated {{SanitizerConfig}}
-<dfn export for="TrustedParserOptions">sanitizer</dfn>.
+A {{TrustedParserOptions}} has an associated {{SanitizerConfig}}-or-null
+<dfn export for="TrustedParserOptions">sanitizer config</dfn>.
 
 <div algorithm>
 The <dfn method for="TrustedParserOptions">sanitizer()</dfn> method steps are:
 
-1. Let |sanitizer| be a new {{Sanitizer}} in <span>this</span>'s [=relevant realm=], whose [=Sanitizer/configuration=] is <span>this</span>'s [=TrustedParserOptions/sanitizer=].
-2. Return |sanitizer|.
+1. If <span>this</span>'s [=TrustedParserOptions/sanitizer config=] is null, return null.
+1. Let |sanitizer| be a new {{Sanitizer}} in <span>this</span>'s [=relevant realm=], whose [=Sanitizer/configuration=] is <span>this</span>'s [=TrustedParserOptions/sanitizer config=].
+1. Return |sanitizer|.
 
 </div>
 
@@ -1255,11 +1256,11 @@ a string |value| and a list |arguments|, perform the following steps:
     1.  Let |runScripts| be false.
     1.  If |policyValue| is a [=dictionary=]:
         1.  Set |sanitizer| to the result of
-            [=get a sanitizer configuration from dictionary|getting a sanitizer configuration=]
+            [=get a sanitizer config from dictionary|getting a sanitizer configuration=]
             from |policyValue|.
         1.  Set |runScripts| to |policyValue|["runScripts"] [=with default=] false.
     1.  Return a new instance of {{TrustedParserOptions}} with its
-        [=TrustedParserOptions/sanitizer=] set to |sanitizer|, and its
+        [=TrustedParserOptions/sanitizer config=] set to |sanitizer|, and its
         [=TrustedParserOptions/runScripts=] set to |runScripts|.
 1.  Let |dataString| be the result of stringifying |policyValue|.
 1.  If |policyValue| is null or undefined, set |dataString| to the empty string.
@@ -1310,12 +1311,11 @@ a string |value|, a list |arguments|, and a boolean |throwIfMissing|, perform th
 ## Get Trusted Type parser input ## {#get-trusted-type-parser-input-algorithm}
 
 To <dfn export>get Trusted Type compliant input</dfn> given a {{TrustedType}} |expectedType|, a [=realm/global object=] |global|, a string or <code data-x="">Stream</code> |input|,
-a {{TrustedParserOptions}}, {{SetHTMLUnsafeOptions}} or <code data-x="">Legacy</code> |options|, and a string |sink|:
+a {{TrustedParserOptions}} or {{SetHTMLUnsafeOptions}} |options|, and a string |sink|:
 
 1. If |input| is not a <code data-x="">Stream</code>:
     1. Set |input| to the result of calling get trusted type compliant string, passing |expectedType|, |global|, |input|, |sink|, and `"TrustedHTML"`.
     1. If the algorithm threw an error, rethrow the error.
-1. If |options| is <code data-x="">Legacy</code>, set |options| to a new {{SetHTMLUnsafeOptions}} dictionary.
 1. Let |throwIfMissing| be true if |input| is not a <code data-x="">Stream</code>; otherwise false.
 1. Set |options| to the result of calling [=get Trusted Type compliant parser options=], passing |global|, |options|, |throwIfMissing|, and |sink|.
 1. If the algorithm threw an error, rethrow the error.
@@ -1365,7 +1365,8 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
     1. If |throwIfMissing| is true, throw a {{TypeError}}.
     1. Return |input|.
 1. Let |runScriptsInput| be |input|["runScripts"], [=with default=] false.
-1. Let |sanitizerInput| be the results of [=get a new sanitizer from dictionary|getting a new sanitizer=] from |input|.
+1. Let |sanitizerInputConfig| be the results of [=get a sanitizer config from dictionary|getting a sanitizer config=] from |input|.
+1. Let |sanitizerInput| be null if |sanitizerInputConfig| is null; otherwise a new {{Sanitizer}}, [=configure|configured=] withh |sanitizerInputConfig|.
 1. Let |argument| be the [=ordered map=] «[ "runScripts" → |runScriptsInput|, "sanitizer" → |sanitizerInput| ]».
 1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument| » and `"rethrow"`.
 1. If the algorithm threw an error, rethrow the error and abort the following steps.
@@ -1379,26 +1380,17 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
     1. Throw a {{TypeError}}.
 1. Let |runScripts| be true if |policyValue|["`runScripts`"] is true and |input| is a {{SetHTMLUnsafeOptions}} whose {{SetHTMLUnsafeOptions/runScripts}} is true.
 1. Return a new {{TrustedParserOptions}} in |input|'s [=relevant realm=]
-    whose [=TrustedParserOptions/sanitizer=] is set to the result of
-    [=get a sanitizer configuration from dictionary|getting a sanitizer configuration=] from
+    whose [=TrustedParserOptions/sanitizer config=] is set to the result of
+    [=get a sanitizer config from dictionary|getting a sanitizer configuration=] from
     |policyValue|,
     and whose [=TrustedParserOptions/runScripts=] is set to |runScripts|.
 
-To <dfn>get a sanitizer configuration from dictionary</dfn> given a dictionary |dictionary|:
+To <dfn>get a sanitizer config from dictionary</dfn> given a dictionary |dictionary|:
 1. Let |sanitizerInput| be |dictionary|["`sanitizer`"], [=with default|defaulting to=] a new
     {{SanitizerConfig}}.
 1. If |sanitizerInput| is a {{Sanitizer}}, set it to |sanitizerInput|'s
     [=Sanitizer/configuration=].
 1. Return |sanitizerInput|.
-
-To <dfn>get a new sanitizer from dictionary</dfn> given a dictionary |dictionary|:
-1. Let |sanitizerInput| be the result of
-    [=get a sanitizer configuration from dictionary|getting a sanitizer configuration=] from
-    |dictionary|.
-1. Let |sanitizer| be a new {{Sanitizer}} in |dictionary|'s [=realm=].
-1. [=configure|Configure=] |sanitizer| with |sanitizerInput| and true.
-1. Return |sanitizer|.
-
 
 
 ## Process value with a default policy ## {#process-value-with-a-default-policy-algorithm}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -236,9 +236,9 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     type: dfn; text: event handler content attribute; url: event-handler-content-attributes
     type: dfn; text: configuration; for: Sanitizer; url: configuration
     type: dfn; text: canonicalize the configuration; url: canonicalize-the-configuration
-    type:dictionary; text:Sanitizer
+    type:interface; text:Sanitizer
     type:dictionary; text:SanitizerConfig
-    type:dictionary; text:SanitizerPresets
+    type:enum; text:SanitizerPresets
     type:dictionary; text:SetHTMLOptions
     type:dictionary; text:SetHTMLUnsafeOptions
 spec:DOM; urlPrefix: https://dom.spec.whatwg.org/
@@ -731,9 +731,9 @@ Note: When enforcing Trusted Types on HTML injection sinks that parse markup (su
 without requiring {{TrustedTypePolicyOptions/createHTML}} or a {{TrustedHTML}} instance. For string-only injection sinks that do not support parser options
 (such as {{HTMLIFrameElement/srcdoc}} or `document.write()`), raw strings must still be converted via {{TrustedTypePolicyOptions/createHTML}}.
 
-Note: The `sanitizer` option is only supported for HTML documents. If `createParserOptions`
-returns a dictionary with a non-null `sanitizer` value for an XML document, the sink throws
-an exception. When protecting XML documents, authors are advised to use `createHTML` instead.
+Note: When used in legacy HTML injection sinks such as {{Element/innerHTML}}, the `sanitizer` option is only supported for HTML documents.
+If `createParserOptions` returns a dictionary with a non-null `sanitizer` value for a legacy sink in an XML document, the sink throws a {{TypeError}}.
+When protecting XML documents using legacy sinks, authors are advised to use `createHTML` instead.
 
 ### <dfn interface>TrustedTypePolicyFactory</dfn> ### {#trusted-type-policy-factory}
 
@@ -1319,7 +1319,9 @@ a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions
 1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
 1. If the algorithm threw an error, rethrow the error.
 1. If |input| is an instance of {{TrustedHTML}}:
-    1. Return (stringified |input|, |compliantOptions|).
+    1. Let |runScripts| be true if |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/runScripts=] is true, or if |compliantOptions| is a dictionary and |compliantOptions|["runScripts"], [=with default=] false is true; otherwise false.
+    1. Let |trustedOptions| be a new {{TrustedParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedParserOptions/sanitizer config=] is null and whose [=TrustedParserOptions/runScripts=] is |runScripts|.
+    1. Return (stringified |input|, |trustedOptions|).
 1. If |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer config=] is not null:
     1. Return (stringified |input|, |compliantOptions|).
 1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
@@ -1386,7 +1388,7 @@ When streaming or in contexts where the HTML string cannot be validated up front
 1. Let |argument| be the [=ordered map=] «[ "runScripts" → |runScriptsInput| ]».
 1. Let |sanitizerInputConfig| be the results of [=get a sanitizer config from dictionary|getting a sanitizer config=] from |input|.
 1. If |sanitizerInputConfig| is not null:
-    1. Let |sanitizerInput| be a new {{Sanitizer}}, [=configure|configured=] with |sanitizerInputConfig|.
+    1. Let |sanitizerInput| be a new {{Sanitizer}}, [=configure|configured=] with |sanitizerInputConfig| and true.
     1. Set |argument|["sanitizer"] to |sanitizerInput|.
 1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument| » and `"rethrow"`.
 1. If the algorithm threw an error, rethrow the error and abort the following steps.
@@ -1398,7 +1400,7 @@ When streaming or in contexts where the HTML string cannot be validated up front
         Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.
 
     1. Throw a {{TypeError}}.
-1. Let |runScripts| be true if |policyValue|["runScripts"] is true and |input| is a {{SetHTMLUnsafeOptions}} whose {{SetHTMLUnsafeOptions/runScripts}} is true.
+1. Let |runScripts| be true if |policyValue|["runScripts"] is true and |runScriptsInput| is true; otherwise false.
 1. Return a new {{TrustedParserOptions}} in |global|'s [=relevant realm=]
     whose [=TrustedParserOptions/sanitizer config=] is set to the result of
     [=get a sanitizer config from dictionary|getting a sanitizer configuration=] from
@@ -1409,7 +1411,7 @@ To <dfn>get a sanitizer config from dictionary</dfn> given a dictionary |diction
 1. Let |sanitizerInput| be |dictionary|["sanitizer"], [=with default|defaulting to=] null.
 1. If |sanitizerInput| is a {{Sanitizer}}, return a [=map/clone=] of |sanitizerInput|'s [=Sanitizer/configuration=].
 1. If |sanitizerInput| is a {{SanitizerPresets}} or a {{SanitizerConfig}}:
-    1. Let |sanitizer| be a new {{Sanitizer}}, [=configure|configured=] with |sanitizerInput|.
+    1. Let |sanitizer| be a new {{Sanitizer}}, [=configure|configured=] with |sanitizerInput| and true.
     1. Return a [=map/clone=] of |sanitizer|'s [=Sanitizer/configuration=].
 1. Return null.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1258,7 +1258,7 @@ a string or dictionary |value| and a list |arguments|, perform the following ste
 1.  If |trustedTypeName| is `"TrustedParserOptions"`:
     1.  If |policyValue| is not a [=dictionary=], throw a {{TypeError}}.
     1.  Let |sanitizer| be the result of
-        [=get a sanitizer config from dictionary|getting a sanitizer configuration=]
+        [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=]
         from |policyValue|.
     1.  Let |runScripts| be |policyValue|["runScripts"] [=with default=] false.
     1.  Return a new instance of {{TrustedParserOptions}} in |policy|'s [=relevant realm=] with its
@@ -1319,7 +1319,7 @@ a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions
 1. If the algorithm threw an error, rethrow the error.
 1. If |input| is an instance of {{TrustedHTML}}:
     1. Let |runScripts| be |compliantOptions|'s [=TrustedParserOptions/runScripts=] if |compliantOptions| is an instance of {{TrustedParserOptions}}; otherwise |compliantOptions|["runScripts"], [=with default=] false.
-    1. Let |sanitizerConfig| be |options|'s [=TrustedParserOptions/sanitizer config=] if |options| is an instance of {{TrustedParserOptions}}; otherwise the result of [=get a sanitizer config from dictionary|getting a sanitizer configuration=] from |options|.
+    1. Let |sanitizerConfig| be |options|'s [=TrustedParserOptions/sanitizer config=] if |options| is an instance of {{TrustedParserOptions}}; otherwise the result of [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from |options|.
     1. Let |trustedOptions| be a new {{TrustedParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedParserOptions/sanitizer config=] is |sanitizerConfig| and whose [=TrustedParserOptions/runScripts=] is |runScripts|.
     1. Return (stringified |input|, |trustedOptions|).
 1. If |options| is an instance of {{TrustedParserOptions}}, return (stringified |input|, |compliantOptions|).
@@ -1386,7 +1386,7 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
     1. Return |input|.
 1. Let |runScriptsInput| be |input|["runScripts"], [=with default=] false.
 1. Let |argument| be the [=ordered map=] «[ "runScripts" → |runScriptsInput| ]».
-1. Let |sanitizerInputConfig| be the results of [=get a sanitizer config from dictionary|getting a sanitizer config=] from |input|.
+1. Let |sanitizerInputConfig| be the results of [=get a sanitizer config copy from dictionary|getting a sanitizer config=] from |input|.
 1. If |sanitizerInputConfig| is not null:
     1. Let |sanitizerInput| be a new {{Sanitizer}} in |global|'s [=relevant realm=], [=configure|configured=] with |sanitizerInputConfig| and true.
     1. Set |argument|["sanitizer"] to |sanitizerInput|.
@@ -1403,11 +1403,11 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
 1. Let |runScripts| be true if |policyValue|["runScripts"] is true and |runScriptsInput| is true; otherwise false.
 1. Return a new {{TrustedParserOptions}} in |global|'s [=relevant realm=]
     whose [=TrustedParserOptions/sanitizer config=] is set to the result of
-    [=get a sanitizer config from dictionary|getting a sanitizer configuration=] from
+    [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from
     |policyValue|,
     and whose [=TrustedParserOptions/runScripts=] is set to |runScripts|.
 
-To <dfn>get a sanitizer config from dictionary</dfn> given a dictionary |dictionary|:
+To <dfn>get a sanitizer config copy from dictionary</dfn> given a dictionary |dictionary|:
 1. Let |sanitizerInput| be |dictionary|["sanitizer"], [=with default|defaulting to=] null.
 1. Let |config| be null.
 1. If |sanitizerInput| is a {{SanitizerPresets}}:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1291,18 +1291,18 @@ a string |value|, a list |arguments|, and a boolean |throwIfMissing|, perform th
 
 ## Get Trusted Type parser input ## {#get-trusted-type-parser-input-algorithm}
 
-To <dfn export>get Trusted Type compliant input</dfn> given a {{TrustedType}} |expectedType|, a [=realm/global object=] (|global|), string, or <code data-x="">Stream</code> |input|,
-a {{TrustedParserOptions}}, {{SetHTMLUnsafeOptions}} or <code data-x="">Legacy</code> |options|, and a string (|sink|), run these steps:
+To <dfn export>get Trusted Type compliant input</dfn> given a {{TrustedType}} |expectedType|, a [=realm/global object=] |global|, a string or <code data-x="">Stream</code> |input|,
+a {{TrustedParserOptions}}, {{SetHTMLUnsafeOptions}} or <code data-x="">Legacy</code> |options|, and a string |sink|:
 
 1. Let |sinkGroup| be 
 
 1. If |input| is not a <code data-x="">Stream</code>:
-  1. Set |input| to the result of calling get trusted type compliant string, passing |expectedType|, |global|, |input|, |sink| and |sinkGroup|.
-  1. If the algorithm threw an error, rethrow the error and abort the following steps.
+  1. Set |input| to the result of calling get trusted type compliant string, passing |expectedType|, |global|, |input|, |sink|, and |sinkGroup|.
+  1. If the algorithm threw an error, rethrow the error.
 1. If |options| is <code data-x="">Legacy</code>, set |options| to a new {{SetHTMLUnsafeOptions}} dictionary.
-1. Let |throwIfMissing| be true if |input| is not a <code data-x="">Stream</code>; Otherwise false.
+1. Let |throwIfMissing| be true if |input| is not a <code data-x="">Stream</code>; otherwise false.
 1. Set |options| to the result of calling [=get Trusted Type compliant parser options=], passing |global|, |options|, |throwIfMissing|, |sink|, and |sinkGroup|.
-1. If the algorithm threw an error, rethrow the error and abort the following steps.
+1. If the algorithm threw an error, rethrow the error.
 1. Return (|input|, |options|).
 
 ## Get Trusted Type compliant string ## {#get-trusted-type-compliant-string-algorithm}
@@ -1364,7 +1364,7 @@ To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/g
 1. Let |sanitizer| be |policyValue|["`sanitizer`"], [=with default|defaulting to=] a new {{SanitizerConfig}}.
 1. If |sanitizer| is a {{Sanitizer}}, then set |sanitizer| to a new {{Sanitizer}} whose [=Sanitizer/configuration=] is the result of [=canonicalize the configuration|canonicalizing=] |sanitizer|'s [=Sanitizer/configuration=].
 
-  This step assures that the provided {{Sanitizer}} is not mutated by the policy.
+  Note: This step assures that the provided {{Sanitizer}} is not mutated by the policy.
 
 1. Let |runScripts| be true if |policyValue|["`runScripts`"] is true and |input| is a {{SetHTMLUnsafeOptions}} whose {{SetHTMLUnsafeOptions/runScripts}} is true.
 1. Return a new {{TrustedParserOptions}} in |input|'s [=relevant realm=]

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1319,7 +1319,7 @@ a {{TrustedParserOptions}} or {{SetHTMLUnsafeOptions}} |options|, and a string |
 1. If |input| is not a <code data-x="">Stream</code>:
     1. Set |input| to the result of calling [=get trusted type compliant string=], passing `"TrustedHTML"`, |global|, |input|, |sink|, and `"script"`.
     1. If the algorithm threw an error, rethrow the error.
-1. Let |throwIfMissing| be true if |input| is not a <code data-x="">Stream</code>; otherwise false.
+1. Let |throwIfMissing| be true if |input| is a <code data-x="">Stream</code>; otherwise false.
 1. Set |options| to the result of calling [=get Trusted Type compliant parser options=], passing |global|, |options|, |throwIfMissing|, and |sink|.
 1. If the algorithm threw an error, rethrow the error.
 1. Return (|input|, |options|).
@@ -1389,8 +1389,7 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
     and whose [=TrustedParserOptions/runScripts=] is set to |runScripts|.
 
 To <dfn>get a sanitizer config from dictionary</dfn> given a dictionary |dictionary|:
-1. Let |sanitizerInput| be |dictionary|["`sanitizer`"], [=with default|defaulting to=] a new
-    {{SanitizerConfig}}.
+1. Let |sanitizerInput| be |dictionary|["`sanitizer`"], [=with default|defaulting to=] null.
 1. If |sanitizerInput| is a {{Sanitizer}}, set it to |sanitizerInput|'s
     [=Sanitizer/configuration=].
 1. Return |sanitizerInput|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -584,17 +584,27 @@ These objects are immutable wrappers around a
 
 [Exposed=(Window)]
 interface TrustedParserOptions {
-  readonly attribute Sanitizer sanitizer;
+  Sanitizer sanitizer();
   readonly attribute boolean runScripts;
 };
 </pre>
 
-{{TrustedParserOptions}} objects have an associated {{Sanitizer}} <dfn export for="TrustedParserOptions">sanitizer</dfn>
-and an associated boolean <dfn export for="TrustedParserOptions">runScripts</dfn>.
+{{TrustedParserOptions}} objects have an associated boolean <dfn export for="TrustedParserOptions">runScripts</dfn>.
 These values are set when the object is created, and will never change during its lifetime.
 
-A {{TrustedParserOptions}} also has an associated {{Sanitizer}} <dfn export for="TrustedParserOptions">effective sanitizer</dfn>,
-which remains unaffected if the object's {{TrustedParserOptions/sanitizer}} is mutated.
+The {{TrustedParserOptions/runScripts}} getter steps are to return [=this=]'s associated
+[=TrustedParserOptions/runScripts=].
+
+A {{TrustedParserOptions}} has an associated {{SanitizerConfig}}
+<dfn export for="TrustedParserOptions">sanitizer</dfn>.
+
+<div algorithm>
+The <dfn method for="TrustedParserOptions">sanitizer()</dfn> method steps are:
+
+1. Let |sanitizer| be a new {{Sanitizer}} in <span>this</span>'s [=relevant realm=].
+2. [=configure|Configure=] |sanitizer| with <span>this</span>'s [=TrustedParserOptions/sanitizer=] and true.
+3. Return |sanitizer|.
+</div>
 
 ## <dfn>Policies</dfn> ## {#policies-hdr}
 
@@ -1239,17 +1249,16 @@ a string |value| and a list |arguments|, perform the following steps:
 1.  Let |policyValue| be the result of executing [=get trusted type policy value=] with the same arguments as this algorithm and additionally true as |throwIfMissing|.
 1.  If the algorithm threw an error, rethrow the error and abort the following steps.
 1. If |trustedTypeName| is "TrustedParserOptions":
-  1. Let |sanitizer| be an empty {{SanitizerConfig}}.
-  1. Let |sanitizerClone| be an empty {{SanitizerConfig}}.
-
-    Note: setting both |sanitizer| and |sanitizerClone| ensures that in-place changes to {{TrustedParserOptions/sanitizer}} will not modify the underlying options.
-
+  1. Let |sanitizer| be a new {{SanitizerConfig}}.
   1. Let |runScripts| be false.
   1. If |policyValue| is a [=dictionary=]:
-    1. Set |sanitizer| to the result of [=get a new sanitizer from dictionary|getting a new sanitizer=] from |policyValue|.
-    1. Set |sanitizerClone| to the result of [=get a new sanitizer from dictionary|getting a new sanitizer=] from |policyValue|.
+    1. Set |sanitizer| to the result of
+        [=get a sanitizer configuration from dictionary|getting a sanitizer configuration=]
+        from |policyValue|.
     1. Set |runScripts| to |policyValue|["runScripts"] [=with default=] false.
-  1. Return a new instance of {{TrustedParserOptions}} with its [=TrustedParserOptions/sanitizer=] set to |sanitizer|, its [=TrustedParserOptions/effective sanitizer=] set to |sanitizerClone|, and its [=TrustedParserOptions/runScripts=] set to |runScripts|.
+  1. Return a new instance of {{TrustedParserOptions}} with its
+      [=TrustedParserOptions/sanitizer=] set to |sanitizer|, and its
+      [=TrustedParserOptions/runScripts=] set to |runScripts|.
 1.  Let |dataString| be the result of stringifying |policyValue|.
 1.  If |policyValue| is null or undefined, set |dataString| to the empty string.
 1.  Return a new instance of an interface with a type
@@ -1370,13 +1379,23 @@ a boolean |throwIfMissing|, a string |sink| and a string |sinkGroup|, run these 
     1. Throw a {{TypeError}}.
 1. Let |runScripts| be true if |policyValue|["`runScripts`"] is true and |input| is a {{SetHTMLUnsafeOptions}} whose {{SetHTMLUnsafeOptions/runScripts}} is true.
 1. Return a new {{TrustedParserOptions}} in |input|'s [=relevant realm=]
-    whose [=TrustedParserOptions/sanitizer=] is set to [=get a new sanitizer from dictionary|getting the sanitizer=] from |policyValue|,
+    whose [=TrustedParserOptions/sanitizer=] is set to the result of
+    [=get a sanitizer configuration from dictionary|getting a sanitizer configuration=] from
+    |policyValue|,
     and whose [=TrustedParserOptions/runScripts=] is set to |runScripts|.
 
-To <dfn>get a new sanitizer from dictionary</dfn>
-1. Let |sanitizerInput| be |policyValue|["`sanitizer`"], [=with default|defaulting to=] a new {{SanitizerConfig}}.
-1. If |sanitizerInput| is a {{Sanitizer}}, set it to |sanitizerInput|'s [=Sanitizer/configuration=].
-1. Let |sanitizer| be a new {{Sanitizer}} in |policyValue|'s [=realm=].
+To <dfn>get a sanitizer configuration from dictionary</dfn> given a dictionary |dictionary|:
+1. Let |sanitizerInput| be |dictionary|["`sanitizer`"], [=with default|defaulting to=] a new
+    {{SanitizerConfig}}.
+1. If |sanitizerInput| is a {{Sanitizer}}, set it to |sanitizerInput|'s
+    [=Sanitizer/configuration=].
+1. Return |sanitizerInput|.
+
+To <dfn>get a new sanitizer from dictionary</dfn> given a dictionary |dictionary|:
+1. Let |sanitizerInput| be the result of
+    [=get a sanitizer configuration from dictionary|getting a sanitizer configuration=] from
+    |dictionary|.
+1. Let |sanitizer| be a new {{Sanitizer}} in |dictionary|'s [=realm=].
 1. [=configure|Configure=] |sanitizer| with |sanitizerInput| and true.
 1. Return |sanitizer|.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -573,7 +573,7 @@ TrustedScriptURL object are to return the associated [=TrustedScriptURL/data=] v
 
 ### <dfn interface>TrustedParserOptions</dfn> ### {#trused-parser-options}
 
-The TrustedParserOptions interface represents a dictionary that a developer
+The {{TrustedParserOptions}} interface represents a dictionary that a developer
 can confidently pass into an [=injection sink=] that will parse it as a URL of
 an external script resource.
 These objects are immutable wrappers around a

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1370,7 +1370,6 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
 1. Let |runScriptsInput| be |input|["runScripts"], [=with default=] false.
 1. Let |sanitizerInputConfig| be the results of [=get a sanitizer config from dictionary|getting a sanitizer config=] from |input|.
 1. Let |sanitizerInput| be null if |sanitizerInputConfig| is null; otherwise a new {{Sanitizer}}, [=configure|configured=] withh |sanitizerInputConfig|.
-1. If |sanitizerInput| is not null and |global|'s [=associated Document=]'s [=Document/type=] is `"xml"`, throw a {{TypeError}}.
 1. Let |argument| be the [=ordered map=] «[ "runScripts" → |runScriptsInput|, "sanitizer" → |sanitizerInput| ]».
 1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument| » and `"rethrow"`.
 1. If the algorithm threw an error, rethrow the error and abort the following steps.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -731,8 +731,9 @@ using the built-in sanitizer API.
 Note: `createParserOptions` does not necessarily replace `createHTML`. If both exist in the policy, the `createHTML` function will be called first,
 and the result will be sanitized using the result of the `createParserOptions` function, if that exists.
 
-Note: The `"sanitizer"` value only works with HTML documents. Returning a non-null value for `"sanitizer"` for XML documents throws an exception.
-When protecting XML documents, authors are advised to use `createHTML` instead and perform sanitization using JavaScript.
+Note: The `sanitizer` option is only supported for HTML documents. If `createParserOptions`
+returns a dictionary with a non-null `sanitizer` value for an XML document, the sink throws
+an exception. When protecting XML documents, authors are advised to use `createHTML` instead.
 
 ### <dfn interface>TrustedTypePolicyFactory</dfn> ### {#trusted-type-policy-factory}
 
@@ -1313,16 +1314,14 @@ a string |value|, a list |arguments|, and a boolean |throwIfMissing|, perform th
 
 ## Get Trusted Type parser input ## {#get-trusted-type-parser-input-algorithm}
 
-To <dfn export>get Trusted Type compliant input</dfn> given a [=realm/global object=] |global|, a string or <code data-x="">Stream</code> |input|,
+To <dfn export>get Trusted Type compliant input</dfn> given a [=realm/global object=] |global|, a string |input|,
 a {{TrustedParserOptions}} or {{SetHTMLUnsafeOptions}} |options|, and a string |sink|:
 
-1. If |input| is not a <code data-x="">Stream</code>:
-    1. Set |input| to the result of calling [=get trusted type compliant string=], passing `"TrustedHTML"`, |global|, |input|, |sink|, and `"script"`.
-    1. If the algorithm threw an error, rethrow the error.
-1. Let |throwIfMissing| be true if |input| is a <code data-x="">Stream</code>; otherwise false.
-1. Set |options| to the result of calling [=get Trusted Type compliant parser options=], passing |global|, |options|, |throwIfMissing|, and |sink|.
+1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing `"TrustedHTML"`, |global|, |input|, |sink|, and `"script"`.
 1. If the algorithm threw an error, rethrow the error.
-1. Return (|input|, |options|).
+1. Let |compliantOptions| be the result of calling [=get Trusted Type compliant parser options=], passing |global|, |options|, false, and |sink|.
+1. If the algorithm threw an error, rethrow the error.
+1. Return (|compliantHTML|, |compliantOptions|).
 
 ## Get Trusted Type compliant string ## {#get-trusted-type-compliant-string-algorithm}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1068,7 +1068,7 @@ dictionary TrustedTypePolicyOptions {
 callback CreateHTMLCallback = DOMString? (DOMString input, any... arguments);
 callback CreateScriptCallback = DOMString? (DOMString input, any... arguments);
 callback CreateScriptURLCallback = USVString? (DOMString input, any... arguments);
-callback CreateParserOptionsCallback = SetHTMLUnsafeOptions? (optional SetHTMLUnsafeOptions options, any... arguments);
+callback CreateParserOptionsCallback = SetHTMLUnsafeOptions? (SetHTMLUnsafeOptions options, any... arguments);
 </pre>
 
 ### <dfn data-lt="default-policy-explanation">Default policy</dfn> ### {#default-policy-hdr}
@@ -1260,7 +1260,7 @@ a string or dictionary |value| and a list |arguments|, perform the following ste
     1.  If |policyValue| is not a [=dictionary=], throw a {{TypeError}}.
     1.  Let |sanitizerConfig| be the result of
         [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=]
-        from |policyValue|.
+        from |policy|'s [=relevant realm=] and |policyValue|.
     1.  Let |runScripts| be |policyValue|["runScripts"] [=with default=] false.
     1.  Return a new instance of {{TrustedParserOptions}} in |policy|'s [=relevant realm=] with its
         [=TrustedParserOptions/sanitizer config=] set to |sanitizerConfig|, and its
@@ -1320,16 +1320,13 @@ a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions
 1. If the algorithm threw an error, rethrow the error.
 1. If |input| is an instance of {{TrustedHTML}}:
     1. Let |runScripts| be |compliantOptions|'s [=TrustedParserOptions/runScripts=] if |compliantOptions| is an instance of {{TrustedParserOptions}}; otherwise |compliantOptions|["runScripts"], [=with default=] false.
-    1. Let |sanitizerConfig| be |options|'s [=TrustedParserOptions/sanitizer config=] if |options| is an instance of {{TrustedParserOptions}}; otherwise the result of [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from |options|.
+    1. Let |sanitizerConfig| be |options|'s [=TrustedParserOptions/sanitizer config=] if |options| is an instance of {{TrustedParserOptions}}; otherwise the result of [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from |global|'s [=relevant realm=] and |options|.
     1. Let |trustedOptions| be a new {{TrustedParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedParserOptions/sanitizer config=] is |sanitizerConfig| and whose [=TrustedParserOptions/runScripts=] is |runScripts|.
     1. Return (stringified |input|, |trustedOptions|).
-1. If |options| is an instance of {{TrustedParserOptions}}, return (stringified |input|, |compliantOptions|).
-1. If |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer config=] is not null:
-    1. If |documentType| is `"xml"`:
-        1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
-            passing |global|, |sink|, `"script"`, and stringified |input| as |source|.
-        1. If |disposition| is "Blocked", throw a {{TypeError}}.
-    1. Return (stringified |input|, |compliantOptions|).
+1. If |documentType| is `"html"`:
+    1. If |options| is an instance of {{TrustedParserOptions}}, return (stringified |input|, |compliantOptions|).
+    1. If |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer config=] is not null:
+        1. Return (stringified |input|, |compliantOptions|).
 1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
 1. If the algorithm threw an error, rethrow the error.
 1. Return (|compliantHTML|, |compliantOptions|).
@@ -1391,7 +1388,7 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
     1. Return |input|.
 1. Let |runScriptsInput| be |input|["runScripts"], [=with default=] false.
 1. Let |argument| be the [=ordered map=] «[ "runScripts" → |runScriptsInput| ]».
-1. Let |sanitizerInputConfig| be the results of [=get a sanitizer config copy from dictionary|getting a sanitizer config=] from |input|.
+1. Let |sanitizerInputConfig| be the results of [=get a sanitizer config copy from dictionary|getting a sanitizer config=] from |global|'s [=relevant realm=] and |input|.
 1. If |sanitizerInputConfig| is not null:
     1. Let |sanitizerInput| be a new {{Sanitizer}} in |global|'s [=relevant realm=].
     1. [=configure a sanitizer|Configure=] |sanitizerInput| given |sanitizerInputConfig| and true.
@@ -1414,21 +1411,23 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
 1. Return a new {{TrustedParserOptions}} in |global|'s [=relevant realm=]
     whose [=TrustedParserOptions/sanitizer config=] is set to the result of
     [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from
-    |policyValue|,
+    |global|'s [=relevant realm=] and |policyValue|,
     and whose [=TrustedParserOptions/runScripts=] is set to |runScripts|.
 
-To <dfn>get a sanitizer config copy from dictionary</dfn> given a dictionary |dictionary|:
+To <dfn>get a sanitizer config copy from dictionary</dfn> given a [=realm=] |realm| and a dictionary |dictionary|:
 1. Let |sanitizerInput| be |dictionary|["sanitizer"], [=with default|defaulting to=] null.
+1. If |sanitizerInput| is null, return null.
+1. Let |configuration| be null.
 1. If |sanitizerInput| is a {{SanitizerPresets}}:
     1. [=Assert=]: |sanitizerInput| is `"default"`.
-    1. Return the [=built-in safe default configuration=].
-1. If |sanitizerInput| is a {{Sanitizer}}:
-    1. Return |sanitizerInput|'s [=Sanitizer/configuration=].
-1. If |sanitizerInput| is a {{SanitizerConfig}}:
-    1. Let |sanitizer| be a new {{Sanitizer}}.
-    1. [=configure a sanitizer|Configure=] |sanitizer| given |sanitizerInput| and true.
-    1. Return |sanitizer|'s [=Sanitizer/configuration=].
-1. Return null.
+    1. Set |configuration| to the [=built-in safe default configuration=].
+1. Otherwise, if |sanitizerInput| is a {{Sanitizer}}:
+    1. Set |configuration| to |sanitizerInput|'s [=Sanitizer/configuration=].
+1. Otherwise, if |sanitizerInput| is a {{SanitizerConfig}}:
+    1. Set |configuration| to |sanitizerInput|.
+1. Let |sanitizer| be a new {{Sanitizer}} in |realm|.
+1. [=configure a sanitizer|Configure=] |sanitizer| given |configuration| and true.
+1. Return |sanitizer|'s [=Sanitizer/configuration=].
 
 ## Process value with a default policy ## {#process-value-with-a-default-policy-algorithm}
 
@@ -1953,6 +1952,8 @@ depends on a global state. We advise against this. The policies should
 be self-contained as much as possible. All objects that may alter security decisions
 a policy makes effectively *become* the policy, and should be guarded & reviewed
 together.
+
+A {{TrustedTypePolicyOptions/createParserOptions}} callback that returns a configuration that does not remove unsafe markup (e.g., scripts or event handlers) provides no protection against DOM XSS.
 
 Issue: Refer to the external document on secure policy design.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -259,6 +259,7 @@ spec:webidl; urlPrefix: https://webidl.spec.whatwg.org/
 <pre class="link-defaults">
 spec:fetch; type:dfn; for:/; text:request
 spec:html; type:dfn; for:global object; text:realm
+spec:html; type:dfn; text:configure
 spec:csp3; type:dfn; text:csp list
 spec:csp3; type:dfn; for:global object; text:csp list
 spec:webidl; type:dfn; text:identifier
@@ -581,18 +582,19 @@ These objects are immutable wrappers around a
 
 <pre class="idl">
 
-typedef (Sanitizer or SanitizerConfig or SanitizerPresets) SanitizerInput;
-
 [Exposed=(Window)]
 interface TrustedParserOptions {
-  readonly attribute SanitizerInput sanitizer;
+  readonly attribute Sanitizer sanitizer;
   readonly attribute boolean runScripts;
 };
 </pre>
 
-{{TrustedParserOptions}} objects have an associated {{SanitizerInput}} <dfn export for="TrustedParserOptions">sanitizer</dfn>
+{{TrustedParserOptions}} objects have an associated {{Sanitizer}} <dfn export for="TrustedParserOptions">sanitizer</dfn>
 and an associated boolean <dfn export for="TrustedParserOptions">runScripts</dfn>.
 These values are set when the object is created, and will never change during its lifetime.
+
+A {{TrustedParserOptions}} also has an associated {{Sanitizer}} <dfn export for="TrustedParserOptions">effective sanitizer</dfn>,
+which remains unaffected if the object's {{TrustedParserOptions/sanitizer}} is mutated.
 
 ## <dfn>Policies</dfn> ## {#policies-hdr}
 
@@ -1238,11 +1240,16 @@ a string |value| and a list |arguments|, perform the following steps:
 1.  If the algorithm threw an error, rethrow the error and abort the following steps.
 1. If |trustedTypeName| is "TrustedParserOptions":
   1. Let |sanitizer| be an empty {{SanitizerConfig}}.
+  1. Let |sanitizerClone| be an empty {{SanitizerConfig}}.
+
+    Note: setting both |sanitizer| and |sanitizerClone| ensures that in-place changes to {{TrustedParserOptions/sanitizer}} will not modify the underlying options.
+
   1. Let |runScripts| be false.
   1. If |policyValue| is a [=dictionary=]:
-    1. If |policyValue| has a property named "sanitizer", set |sanitizer| to |policyValue|["sanitizer"].
-    1. If |policyValue| has a property named "runScripts", set |runScripts| to |policyValue|["runScripts"].
-  1. Return a new instance of {{TrustedParserOptions}} with its [=TrustedParserOptions/sanitizer=] set to |sanitizer| and its [=TrustedParserOptions/runScripts=] set to |runScripts|.
+    1. Set |sanitizer| to the result of [=get a new sanitizer from dictionary|getting a new sanitizer=] from |policyValue|.
+    1. Set |sanitizerClone| to the result of [=get a new sanitizer from dictionary|getting a new sanitizer=] from |policyValue|.
+    1. Set |runScripts| to |policyValue|["runScripts"] [=with default=] false.
+  1. Return a new instance of {{TrustedParserOptions}} with its [=TrustedParserOptions/sanitizer=] set to |sanitizer|, its [=TrustedParserOptions/effective sanitizer=] set to |sanitizerClone|, and its [=TrustedParserOptions/runScripts=] set to |runScripts|.
 1.  Let |dataString| be the result of stringifying |policyValue|.
 1.  If |policyValue| is null or undefined, set |dataString| to the empty string.
 1.  Return a new instance of an interface with a type
@@ -1334,8 +1341,9 @@ To <dfn export>get trusted type compliant string</dfn> a {{TrustedType}} type (|
 
 ## Get Trusted Type compliant parser options ## {#get-trusted-type-compliant-parser-options-algorithm}
 
-To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/global object=] (|global|),
-{{TrustedParserOptions}} or a {{SetHTMLUnsafeOptions}} |input|, a boolean |throwIfMissing|, a string |sink| and a string |sinkGroup|, run these steps:
+To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/global object=] |global|,
+|input|, which is either a {{TrustedParserOptions}}, a {{SetHTMLUnsafeOptions}}, or a {{ParseHTMLUnsafeOptions}},
+a boolean |throwIfMissing|, a string |sink| and a string |sinkGroup|, run these steps:
 
 1.  If |input| is an instance of {{TrustedParserOptions}}, return |input|.
 1.  Let |requireTrustedTypes| be the result of executing [=Does sink type require trusted types?=] algorithm,
@@ -1347,10 +1355,9 @@ To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/g
 1.  If |function| is null:
     1. If |throwIfMissing| is true, throw a {{TypeError}}.
     1. Return |input|.
-1. Let |argument| be an [=/ordered map=] whose [=map/entries=] represent the [=dictionary=] passed as |input|.
-
-  Note: This ensures the policy cannot mutate the original options.
-
+1. Let |runScriptsInput| be |input|["runScripts"], [=with default=] false.
+1. Let |sanitizerInput| be the results of [=get a new sanitizer from dictionary|getting a new sanitizer=] from |input|.
+1. Let |argument| be the [=ordered map=] «[ "runScripts" → |runScriptsInput|, "sanitizer" → |sanitizerInput| ]».
 1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument| » and `"rethrow"`.
 1. If the algorithm threw an error, rethrow the error and abort the following steps.
 1. If |policyValue| is `null` or `undefined`:
@@ -1361,15 +1368,19 @@ To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/g
         Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.
 
     1. Throw a {{TypeError}}.
-1. Let |sanitizer| be |policyValue|["`sanitizer`"], [=with default|defaulting to=] a new {{SanitizerConfig}}.
-1. If |sanitizer| is a {{Sanitizer}}, then set |sanitizer| to a new {{Sanitizer}} whose [=Sanitizer/configuration=] is the result of [=canonicalize the configuration|canonicalizing=] |sanitizer|'s [=Sanitizer/configuration=].
-
-  Note: This step assures that the provided {{Sanitizer}} is not mutated by the policy.
-
 1. Let |runScripts| be true if |policyValue|["`runScripts`"] is true and |input| is a {{SetHTMLUnsafeOptions}} whose {{SetHTMLUnsafeOptions/runScripts}} is true.
 1. Return a new {{TrustedParserOptions}} in |input|'s [=relevant realm=]
-    whose [=TrustedParserOptions/sanitizer=] is set to |sanitizer|,
+    whose [=TrustedParserOptions/sanitizer=] is set to [=get a new sanitizer from dictionary|getting the sanitizer=] from |policyValue|,
     and whose [=TrustedParserOptions/runScripts=] is set to |runScripts|.
+
+To <dfn>get a new sanitizer from dictionary</dfn>
+1. Let |sanitizerInput| be |policyValue|["`sanitizer`"], [=with default|defaulting to=] a new {{SanitizerConfig}}.
+1. If |sanitizerInput| is a {{Sanitizer}}, set it to |sanitizerInput|'s [=Sanitizer/configuration=].
+1. Let |sanitizer| be a new {{Sanitizer}} in |policyValue|'s [=realm=].
+1. [=configure|Configure=] |sanitizer| with |sanitizerInput| and true.
+1. Return |sanitizer|.
+
+
 
 ## Process value with a default policy ## {#process-value-with-a-default-policy-algorithm}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1322,6 +1322,9 @@ a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions
     1. Let |sanitizerConfig| be |options|'s [=TrustedParserOptions/sanitizer config=] if |options| is an instance of {{TrustedParserOptions}}; otherwise the result of [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from |options|.
     1. Let |trustedOptions| be a new {{TrustedParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedParserOptions/sanitizer config=] is |sanitizerConfig| and whose [=TrustedParserOptions/runScripts=] is |runScripts|.
     1. Return (stringified |input|, |trustedOptions|).
+
+    Note: this means that when given {{TrustedHTML}} by the caller, the policy's {{TrustedTypePolicyOptions/createParserOptions}} callback can only be used to disable script execution.
+
 1. If |options| is an instance of {{TrustedParserOptions}}, return (stringified |input|, |compliantOptions|).
 1. If |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer config=] is not null:
     1. Return (stringified |input|, |compliantOptions|).
@@ -1401,6 +1404,10 @@ a boolean |throwIfMissing|, and a string |sink|, run these steps:
 
     1. Throw a {{TypeError}}.
 1. Let |runScripts| be true if |policyValue|["runScripts"] is true and |runScriptsInput| is true; otherwise false.
+
+  Note: The {{TrustedTypePolicyOptions/createParserOptions}} method can only disable script execution.
+  It cannot enable script execution when the caller did not request scripts to be executed in the first place.
+
 1. Return a new {{TrustedParserOptions}} in |global|'s [=relevant realm=]
     whose [=TrustedParserOptions/sanitizer config=] is set to the result of
     [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -713,7 +713,6 @@ using the built-in sanitizer API.
 (async function renderFootnote() {
   const footnoteContent = await fetch('/footnote.html').then(r => r.text());
   const policy = trustedTypes.createPolicy('html', {
-    createHTML: input => input,
     createParserOptions: options => {
       const sanitizer = new Sanitizer(options.sanitizer || {});
       sanitizer.removeElement("script");
@@ -727,11 +726,10 @@ using the built-in sanitizer API.
 </xmp>
 </div>
 
-Note: `createParserOptions` does not replace `createHTML`. When enforcing Trusted Types,
-any raw string passed to an HTML injection sink must first be converted via `createHTML`.
-If `createParserOptions` also exists in the policy, the result of `createHTML` will then be
-sanitized using the result of `createParserOptions`. Therefore, a policy used for HTML injection sinks
-should define both `createHTML` and `createParserOptions`.
+Note: When enforcing Trusted Types on HTML injection sinks that parse markup (such as {{Element/setHTMLUnsafe()}} or {{Element/innerHTML}}),
+{{TrustedTypePolicyOptions/createParserOptions}} returning a non-null sanitizer configuration allows raw strings to be parsed and sanitized directly,
+without requiring {{TrustedTypePolicyOptions/createHTML}} or a {{TrustedHTML}} instance. For string-only injection sinks that do not support parser options
+(such as {{HTMLIFrameElement/srcdoc}} or `document.write()`), raw strings must still be converted via {{TrustedTypePolicyOptions/createHTML}}.
 
 Note: The `sanitizer` option is only supported for HTML documents. If `createParserOptions`
 returns a dictionary with a non-null `sanitizer` value for an XML document, the sink throws
@@ -1175,7 +1173,6 @@ Inject a sanitizer when using an HTML injection sink.
 <xmp highlight=js>
 (async function renderFootnote() {
   const defaultPolicy = trustedTypes.createPolicy('default', {
-    createHTML: string => string,
     createParserOptions: options => {
       const sanitizer = new Sanitizer(options.sanitizer || {});
       sanitizer.removeUnsafe();
@@ -1184,7 +1181,6 @@ Inject a sanitizer when using an HTML injection sink.
   });
 
   const trustedOptions = trustedTypes.createPolicy('trusted', {
-    createHTML: string => string,
     createParserOptions: options => options
   }).createParserOptions({});
   const untrustedFootnoteContent = await fetch('/footnote.html').then(r => r.text());
@@ -1320,9 +1316,19 @@ a string or dictionary |value|, a list |arguments|, and a boolean |throwIfMissin
 To <dfn export>get trusted type compliant input</dfn> given a [=realm/global object=] |global|, a string or {{TrustedHTML}} |input|,
 a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, and a string |sink|:
 
-1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
-1. If the algorithm threw an error, rethrow the error.
 1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
+1. If the algorithm threw an error, rethrow the error.
+1. If |input| is an instance of {{TrustedHTML}}:
+    1. Return (stringified |input|, |compliantOptions|).
+1. Let |isSanitizedByParser| be true if |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer config=] is not null; otherwise false.
+1. If |isSanitizedByParser| is true:
+    1. Let |defaultPolicy| be the value of |global|'s [=Window/trusted type policy factory=]'s [=TrustedTypePolicyFactory/default policy=].
+    2. If |defaultPolicy| is not null and |defaultPolicy|'s [=TrustedTypePolicy/options=]["createHTML"] is not null:
+        1. Let |transformedInput| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
+        2. If the algorithm threw an error, rethrow the error.
+        3. Return (|transformedInput|, |compliantOptions|).
+    3. Return (stringified |input|, |compliantOptions|).
+1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
 1. If the algorithm threw an error, rethrow the error.
 1. Return (|compliantHTML|, |compliantOptions|).
 
@@ -1359,7 +1365,7 @@ To <dfn export>get trusted type compliant parser options</dfn> given a [=realm/g
 |input|, which is either a {{TrustedParserOptions}}, a {{SetHTMLUnsafeOptions}}, or a {{ParseHTMLUnsafeOptions}},
 a boolean |throwIfMissing|, and a string |sink|, run these steps:
 
-Note: |throwIfMissing| is false when called alongside [=get trusted type compliant string=] for synchronous injection sinks where the HTML string itself is validated.
+Note: |throwIfMissing| is false when called from [=get trusted type compliant input=]. For synchronous fragment injection sinks, a valid sanitizer configuration in the resulting options can satisfy Trusted Types enforcement without requiring {{TrustedTypePolicyOptions/createHTML}} on the input string.
 When streaming or in contexts where the HTML string cannot be validated up front, callers pass true for |throwIfMissing| to ensure a default policy with {{TrustedTypePolicyOptions/createParserOptions}} is required.
 
 1.  If |input| is an instance of {{TrustedParserOptions}}, return |input|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -234,6 +234,11 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     type: dfn; text: set the inner text steps; url: set-the-inner-text-steps
     type: dfn; text: src; url: attr-script-src
     type: dfn; text: event handler content attribute; url: event-handler-content-attributes
+    type:dictionary; text:Sanitizer
+    type:dictionary; text:SanitizerConfig
+    type:dictionary; text:SanitizerPresets
+    type:dictionary; text:SetHTMLOptions
+    type:dictionary; text:SetHTMLUnsafeOptions
 spec:DOM; urlPrefix: https://dom.spec.whatwg.org/
     type: dfn; text: get text content; url: get-text-content
     type: dfn; text: set text content; url: set-text-content
@@ -579,11 +584,13 @@ typedef (Sanitizer or SanitizerConfig or SanitizerPresets) SanitizerInput;
 [Exposed=(Window)]
 interface TrustedParserOptions {
   readonly attribute SanitizerInput sanitizer;
+  readonly attribute boolean runScripts;
 };
 </pre>
 
-{{TrustedParserOptions}} objects have an associated {{SanitizerInput}} <dfn export for="TrustedParserOptions">sanitizer</dfn>.
-The value is set when the object is created, and will never change during its lifetime.
+{{TrustedParserOptions}} objects have an associated {{SanitizerInput}} <dfn export for="TrustedParserOptions">sanitizer</dfn>
+and an associated boolean <dfn export for="TrustedParserOptions">runScripts</dfn>.
+These values are set when the object is created, and will never change during its lifetime.
 
 ## <dfn>Policies</dfn> ## {#policies-hdr}
 
@@ -1162,8 +1169,11 @@ a string |value| and a list |arguments|, perform the following steps:
 1.  If the algorithm threw an error, rethrow the error and abort the following steps.
 1. If |trustedTypeName| is "TrustedParserOptions":
   1. Let |sanitizer| be an empty {{SanitizerConfig}}.
-  1. If |policyValue| is a [=dictionary=] and has a property named "sanitizer", set |sanitizer| to |policyValue|["sanitizer"].
-  1. Return a new interface of {{TrustedTypePolicyOptions}} with its [=TrustedParserOptions/sanitizer=] set to |sanitizer|.
+  1. Let |runScripts| be false.
+  1. If |policyValue| is a [=dictionary=]:
+    1. If |policyValue| has a property named "sanitizer", set |sanitizer| to |policyValue|["sanitizer"].
+    1. If |policyValue| has a property named "runScripts", set |runScripts| to |policyValue|["runScripts"].
+  1. Return a new instance of {{TrustedParserOptions}} with its [=TrustedParserOptions/sanitizer=] set to |sanitizer| and its [=TrustedParserOptions/runScripts=] set to |runScripts|.
 1.  Let |dataString| be the result of stringifying |policyValue|.
 1.  If |policyValue| is null or undefined, set |dataString| to the empty string.
 1.  Return a new instance of an interface with a type
@@ -1240,23 +1250,36 @@ To <dfn export>get trusted type compliant string</dfn> a {{TrustedType}} type (|
 ## Get Trusted Type compliant parser options ## {#get-trusted-type-compliant-parser-options-algorithm}
 
 To <dfn export>get Trusted Type compliant parser options</dfn> given a [=realm/global object=] (|global|),
-{{TrustedParserOptions}} or a {{SetHTMLOptions}} or a {{SetHTMLUnsafeOptions}} (|input|), a string (|sink|) and a string (|sinkGroup|), run these steps:
+{{TrustedParserOptions}} or a {{SetHTMLOptions}} or a {{SetHTMLUnsafeOptions}} (|input|), a boolean |throwIfMissing|, a string (|sink|) and a string (|sinkGroup|), run these steps:
 
-1.  If |input| is an instance of {{TrustedParserOptions}}, return |input| and abort these steps.
+1.  If |input| is an instance of {{TrustedParserOptions}}, return |input|.
 1.  Let |requireTrustedTypes| be the result of executing [=Does sink type require trusted types?=] algorithm,
     passing |global|, |sinkGroup|, and true.
-1.  If |requireTrustedTypes| is `false`, return |input| and abort these steps.
-1.  Let |convertedInput| be the result of executing [=Process value with a default policy=] with the same arguments as this algorithm.
-1.  If the algorithm threw an error, rethrow the error and abort the following steps.
-1.  If |convertedInput| is `null` or `undefined`, execute the following steps:
-    1.  Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
-        passing |global|, stringified |input| as |source|, |sinkGroup| and |sink|.
-    1.  If |disposition| is `“Allowed”`, return |input| and abort further steps.
+1.  If |requireTrustedTypes| is `false`, return |input|.
+1.  Let |defaultPolicy| be the value of |global|'s [=Window/trusted type policy factory=]'s [=TrustedTypePolicyFactory/default policy=].
+1.  If |defaultPolicy| is null, throw a {{TypeError}}.
+1.  Let |function| be |defaultPolicy|'s [=TrustedTypePolicy/options=]["createParserOptions"].
+1.  If |function| is null:
+    1. If |throwIfMissing| is true, throw a {{TypeError}}.
+    1. Return |input|.
+1. Let |argument| be an [=/ordered map=] whose [=map/entries=] represent the [=dictionary=] passed as |input|.
+
+  Note: This ensures the policy cannot mutate the original options.
+
+1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument| » and `"rethrow"`.
+1. If the algorithm threw an error, rethrow the error and abort the following steps.
+1. If |policyValue| is `null` or `undefined`, execute the following steps:
+    1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
+        passing |global|, |input|, |sinkGroup| and |sink|.
+    1. If |disposition| is `“Allowed”`, return |input| and abort further steps.
 
         Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.
     1. Throw a TypeError and abort further steps.
-1. Assert: |convertedInput| is an instance of |expectedType|.
-1. Return |convertedInput|.
+1. Let |sanitizer| be |policyValue|["`sanitizer`"], [=with default|defaulting to=] a new {{SanitizerConfig}}.
+1. Let |runScripts| be true if |policyValue|["`runScripts`"] is true and |input| is a {{SetHTMLUnsafeOptions}} whose {{SetHTMLUnsafeOptions/runScripts}} is true.
+1. Return a new {{TrustedParserOptions}} in |input|'s [=relevant realm=]
+    whose [=TrustedParserOptions/sanitizer=] is set to |sanitizer|,
+    and whose [=TrustedParserOptions/runScripts=] is set to |runScripts|.
 
 ## Process value with a default policy ## {#process-value-with-a-default-policy-algorithm}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1140,8 +1140,9 @@ algorithms in other specifications, see [[#integrations]].
 While {{TrustedTypePolicyOptions/createHTML|createHTML}} relies on sanitizing strings before they are injected to the parser using a JS sanitizer,
 the {{TrustedTypePolicy/createParserOptions(options, ...arguments)|createParserOptions}} allows the page's default policy to enforce HTML sanitization.
 
-A {{TrustedTypePolicy/createParserOptions(options, ...arguments)|createParserOptions}} callback in a required default policy would run for
-any attempt to inject HTML into a document using script.
+A {{TrustedTypePolicy/createParserOptions(options, ...arguments)|createParserOptions}} callback in a default policy runs whenever
+an HTML fragment sink is invoked with unvetted parser options (or default options), allowing the policy to vet caller-supplied options
+and enforce sanitization even when the input markup is already an instance of {{TrustedHTML}}.
 
 <div class="example" id="require-sanitizer-for-html-injection">
 Enforce Trusted Types at the DOM XSS injection sinks.
@@ -1314,6 +1315,7 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <th>Default policy state / callback</th>
       <th>Result</th>
       <th>Effective <code>runScripts</code></th>
+      <th>Effective <code>sanitizer</code></th>
       <th>Rationale</th>
     </tr>
   </thead>
@@ -1325,65 +1327,82 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>(Ignored)</td>
       <td>Returns `(stringified |input|, |options|)`.</td>
       <td>|options|'s [=TrustedHTMLParserOptions/runScripts=]</td>
-      <td>Caller-supplied {{TrustedHTMLParserOptions}} explicitly authorizes the parse operation, with script execution dictated by the policy that minted it.</td>
+      <td>|options|'s [=TrustedHTMLParserOptions/sanitizer configuration=]</td>
+      <td>Caller-supplied {{TrustedHTMLParserOptions}} explicitly authorizes the parse operation, with script execution and sanitization dictated by the policy that minted it.</td>
     </tr>
     <tr>
-      <td rowspan="5">`"html"`</td>
+      <td rowspan="3">`"html"`</td>
+      <td>Dictionary (caller provides `sanitizer`)</td>
+      <td rowspan="3">{{TrustedHTML}}</td>
+      <td>{{TrustedTypePolicyOptions/createParserOptions}} returns a dictionary configuring a policy sanitizer</td>
+      <td>Returns `(stringified |input|, |compliantOptions|)`.</td>
+      <td>Caller's `runScripts` clamped by policy</td>
+      <td>Configured by {{TrustedTypePolicyOptions/createParserOptions}}</td>
+      <td><strong>Policy vets or replaces caller's sanitizer on TrustedHTML:</strong> Even though |input| is an attested {{TrustedHTML}} instance, {{TrustedTypePolicyOptions/createParserOptions}} runs and receives the caller's sanitizer in `argument["sanitizer"]`. The policy can inspect, enforce, or replace the sanitizer configuration, ensuring unvetted caller-supplied sanitizers cannot bypass policy review.</td>
+    </tr>
+    <tr>
+      <td>Dictionary (caller provides `sanitizer`)</td>
+      <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `{}` (omits sanitizer)</td>
+      <td>Returns `(stringified |input|, |compliantOptions|)`.</td>
+      <td>Caller's `runScripts` clamped by policy</td>
+      <td>`null`</td>
+      <td><strong>Policy strips caller's sanitizer:</strong> The default policy determines the final parser options. If the policy returns no sanitizer, no sanitization is performed during parsing, overriding the caller's request.</td>
+    </tr>
+    <tr>
+      <td>Dictionary (with optional `sanitizer`)</td>
+      <td>No {{TrustedTypePolicyOptions/createParserOptions}} (or no default policy)</td>
+      <td>Returns `(stringified |input|, |options|)`.</td>
+      <td>|options|["runScripts"] (allows `true`)</td>
+      <td>|options|["sanitizer"] (if sink accepts dictionary options; null otherwise)</td>
+      <td><strong>Unvetted pass-through when no parser policy:</strong> When no policy defines {{TrustedTypePolicyOptions/createParserOptions}}, an existing {{TrustedHTML}} instance satisfies Trusted Types directly (bypassing {{TrustedTypePolicyOptions/createHTML}}). Any caller-supplied dictionary options (including `sanitizer` and `runScripts`) pass through unvetted to the sink.</td>
+    </tr>
+    <tr>
+      <td rowspan="8">`"html"`</td>
       <td>Dictionary (`runScripts: false` or omitted)</td>
-      <td rowspan="5">String or {{TrustedHTML}}</td>
+      <td rowspan="2">String</td>
       <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `{ runScripts: true }`</td>
       <td>Returns `(stringified |input|, |compliantOptions|)`.</td>
       <td>`false`</td>
+      <td>Configured by policy (or null)</td>
       <td><strong>Default policy cannot enable scripts:</strong> Even if the default policy returns `runScripts: true`, script execution remains `false` because the caller did not request it (`runScriptsInput` is `false`).</td>
-    </tr>
-    <tr>
-      <td>Dictionary (`runScripts: true`)</td>
-      <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `{ runScripts: false }`</td>
-      <td>Returns `(stringified |input|, |compliantOptions|)`.</td>
-      <td>`false`</td>
-      <td><strong>Default policy disables scripts:</strong> The default policy overrides the caller's request, disallowing script execution.</td>
     </tr>
     <tr>
       <td>Dictionary (`runScripts: true`)</td>
       <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `{ runScripts: true }`</td>
       <td>Returns `(stringified |input|, |compliantOptions|)`.</td>
       <td>`true`</td>
-      <td>Scripts are permitted to execute because both the caller requested it and the default policy allowed it.</td>
+      <td>Configured by policy (or null)</td>
+      <td>Parsing is authorized by the policy-supplied options. Scripts execute because both the caller requested it and the default policy allowed it.</td>
     </tr>
     <tr>
       <td rowspan="2">Dictionary</td>
+      <td rowspan="2">String or {{TrustedHTML}}</td>
       <td>{{TrustedTypePolicyOptions/createParserOptions}} throws an exception</td>
       <td>Rethrows the exception.</td>
       <td>N/A</td>
-      <td>Exceptions in policy callbacks propagate immediately to the caller.</td>
+      <td>N/A</td>
+      <td>Exceptions in policy callbacks propagate immediately to the caller, regardless of whether |input| is a string or {{TrustedHTML}}.</td>
     </tr>
     <tr>
       <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `null` or `undefined`</td>
       <td>Throws a {{TypeError}}.</td>
       <td>N/A</td>
-      <td>Returning null or undefined from a policy callback rejects the value, triggering a CSP violation error.</td>
-    </tr>
-    <tr class="highlight">
-      <td>`"html"`</td>
-      <td>Dictionary</td>
-      <td>{{TrustedHTML}}</td>
-      <td>No {{TrustedTypePolicyOptions/createParserOptions}} (or no default policy)</td>
-      <td>Returns `(stringified |input|, |options|)`.</td>
-      <td>|options|["runScripts"] (allows `true`)</td>
-      <td><strong>TrustedHTML + runScripts:</strong> Because |input| is an attested {{TrustedHTML}} instance, scripts are permitted to execute if requested by the caller (e.g. in {{Range/createContextualFragment()}} or {{Element/setHTMLUnsafe()}} with `runScripts: true`).</td>
+      <td>N/A</td>
+      <td>Returning null or undefined from a policy callback rejects the value, triggering a CSP violation error, regardless of whether |input| is a string or {{TrustedHTML}}.</td>
     </tr>
     <tr>
-      <td rowspan="4">`"html"`</td>
       <td rowspan="4">Dictionary</td>
       <td rowspan="4">String</td>
       <td>No {{TrustedTypePolicyOptions/createParserOptions}}; {{TrustedTypePolicyOptions/createHTML}} returns {{TrustedHTML}}</td>
       <td>Returns `(stringified |convertedInput|, |options|)`.</td>
       <td>|options|["runScripts"]</td>
-      <td>Provides backwards compatibility: when no policy manages parser options, the sink falls back to vetting or sanitizing the markup string via {{TrustedTypePolicyOptions/createHTML}}. Once converted to {{TrustedHTML}}, scripts execute if requested.</td>
+      <td>|options|["sanitizer"] (if sink accepts dictionary options; null otherwise)</td>
+      <td>Provides backwards compatibility: when no policy manages parser options, the sink falls back to vetting or sanitizing the markup string via {{TrustedTypePolicyOptions/createHTML}}. Once converted to {{TrustedHTML}}, scripts and caller-supplied sanitizer options apply if requested.</td>
     </tr>
     <tr>
       <td>No {{TrustedTypePolicyOptions/createParserOptions}}; {{TrustedTypePolicyOptions/createHTML}} throws an exception</td>
       <td>Rethrows the exception.</td>
+      <td>N/A</td>
       <td>N/A</td>
       <td>Exceptions in policy callbacks propagate immediately to the caller.</td>
     </tr>
@@ -1391,11 +1410,13 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>No {{TrustedTypePolicyOptions/createParserOptions}}; {{TrustedTypePolicyOptions/createHTML}} returns `null` or `undefined`</td>
       <td>Throws a {{TypeError}}.</td>
       <td>N/A</td>
+      <td>N/A</td>
       <td>Rejection by {{TrustedTypePolicyOptions/createHTML}} triggers a CSP violation error.</td>
     </tr>
     <tr>
       <td>No default policy (or neither callback defined)</td>
       <td>Throws a {{TypeError}}.</td>
+      <td>N/A</td>
       <td>N/A</td>
       <td>Under enforcing CSP, a raw string cannot be parsed without a policy authorizing either the parser options or the markup string.</td>
     </tr>
@@ -1406,7 +1427,8 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>(Any)</td>
       <td>Returns `(stringified |input|, |options|)`.</td>
       <td>`false`</td>
-      <td>XML sinks require trusted markup; a {{TrustedHTML}} instance satisfies this requirement directly. XML fragment parsing never executes scripts.</td>
+      <td>None (ignored)</td>
+      <td>XML sinks require trusted markup; a {{TrustedHTML}} instance satisfies this requirement directly. XML fragment parsing does not support sanitization and never executes scripts.</td>
     </tr>
     <tr>
       <td rowspan="3">`"xml"`</td>
@@ -1415,11 +1437,13 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>{{TrustedTypePolicyOptions/createHTML}} returns {{TrustedHTML}}</td>
       <td>Returns `(stringified |convertedInput|, |options|)`.</td>
       <td>`false`</td>
-      <td>XML fragment sinks do not support parser options bypass or sanitization; markup strings must always be converted via {{TrustedTypePolicyOptions/createHTML}}. XML fragment parsing never executes scripts.</td>
+      <td>None (ignored)</td>
+      <td>XML fragment sinks do not support parser options bypass or sanitization; markup strings must always be converted via {{TrustedTypePolicyOptions/createHTML}}. XML fragment parsing does not support sanitization and never executes scripts.</td>
     </tr>
     <tr>
       <td>{{TrustedTypePolicyOptions/createHTML}} throws an exception</td>
       <td>Rethrows the exception.</td>
+      <td>N/A</td>
       <td>N/A</td>
       <td>Exceptions in policy callbacks propagate immediately to the caller.</td>
     </tr>
@@ -1427,16 +1451,18 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>No {{TrustedTypePolicyOptions/createHTML}} or no default policy (or returns `null`/`undefined`)</td>
       <td>Throws a {{TypeError}}.</td>
       <td>N/A</td>
+      <td>N/A</td>
       <td>Untrusted strings cannot be injected into XML sinks without {{TrustedTypePolicyOptions/createHTML}}, regardless of parser options.</td>
     </tr>
   </tbody>
 </table>
 
 <div class="note">
-<p><strong>TrustedHTML + runScripts:</strong> Script execution is permitted only when the markup is attested as safe by a policy. Specifically:</p>
+<p><strong>TrustedHTML, runScripts, and sanitization:</strong> Sinks enforcing Trusted Types handle options and scripts as follows:</p>
 <ul>
-  <li>When |input| is a {{TrustedHTML}} instance (or converted into one by {{TrustedTypePolicyOptions/createHTML}}), scripts are allowed to execute if requested by the caller (such as {{Element/setHTMLUnsafe()}} with `runScripts: true`).</li>
-  <li>When |options| is a {{TrustedHTMLParserOptions}}, script execution is governed by the policy that created the options object. A default policy's {{TrustedTypePolicyOptions/createParserOptions}} can only clamp script execution to `false`; it can never enable scripts if the caller did not request them (`runScriptsInput` is `false`).</li>
+  <li>When |input| is a {{TrustedHTML}} instance, a default policy's {{TrustedTypePolicyOptions/createParserOptions}} still vets any caller-supplied options dictionary, allowing the policy to inspect, configure, or override the sanitizer configuration (and clamp script execution) despite the input already being {{TrustedHTML}}. If {{TrustedTypePolicyOptions/createParserOptions}} throws or returns `null` or `undefined`, the operation is rejected. Only when {{TrustedTypePolicyOptions/createParserOptions}} is absent do the caller's dictionary options pass through unvetted.</li>
+  <li>When |options| is a {{TrustedHTMLParserOptions}}, script execution and sanitization are governed by the policy that created the options object. A default policy's {{TrustedTypePolicyOptions/createParserOptions}} can only clamp script execution to `false`; it can never enable scripts if the caller did not request them (`runScriptsInput` is `false`).</li>
+  <li>XML fragment parsing does not support sanitization and never executes scripts; any sanitizer configuration or `runScripts` flag is ignored for XML sinks.</li>
   <li>In report-only mode or when Trusted Types enforcement is not required for the sink, a {{TypeError}} is not thrown on violation; instead, the original stringified |input| and |options| are returned.</li>
   <li>For streaming HTML fragment parsing, [=get trusted type compliant parser options=] is invoked directly with |throwIfMissing| set to true. In that context, if {{TrustedTypePolicyOptions/createParserOptions}} is missing, throws, or returns `null` or `undefined`, a {{TypeError}} is thrown (or rethrown) immediately.</li>
 </ul>
@@ -2067,6 +2093,10 @@ a policy makes effectively *become* the policy, and should be guarded & reviewed
 together.
 
 A {{TrustedTypePolicyOptions/createParserOptions}} callback that returns a configuration that does not remove unsafe markup (e.g., scripts or event handlers) provides no protection against DOM XSS.
+Policy authors should also carefully inspect any caller-supplied sanitizer in the `argument["sanitizer"]` passed to {{TrustedTypePolicyOptions/createParserOptions}}.
+Blindly trusting or passing through a caller's sanitizer allows unvetted configurations to govern parsing.
+Because {{TrustedTypePolicyOptions/createParserOptions}} executes even when the input markup is an existing {{TrustedHTML}} instance,
+the default policy ensures that unvetted caller options cannot bypass application-wide sanitization or script execution constraints.
 
 Issue: Refer to the external document on secure policy design.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1362,7 +1362,7 @@ When streaming or in contexts where the HTML string cannot be validated up front
 
 To <dfn export>get trusted type compliant parser options</dfn> given a [=realm/global object=] |global|,
 |input|, which is either a {{TrustedParserOptions}}, a {{SetHTMLUnsafeOptions}}, or a {{ParseHTMLUnsafeOptions}},
-a boolean |throwIfMissing|, and a string |sink|, run these steps:
+a boolean |throwIfMissing|, and a string |sink|:
 
 1.  If |input| is an instance of {{TrustedParserOptions}}, return |input|.
 1.  Let |requireTrustedTypes| be the result of executing [=Does sink type require trusted types?=] algorithm,

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -590,7 +590,7 @@ interface TrustedParserOptions {
 </pre>
 
 {{TrustedParserOptions}} objects have an associated boolean <dfn export for="TrustedParserOptions">runScripts</dfn>
-and an associated {{SanitizerConfig}}-or-null <dfn export for="TrustedParserOptions">sanitizer config</dfn>.
+and an associated {{SanitizerConfig}}-or-null <dfn export for="TrustedParserOptions">sanitizer configuration</dfn>.
 These values are set when the object is created, and will never change during its lifetime.
 
 The {{TrustedParserOptions/runScripts}} getter steps are to return [=this=]'s associated
@@ -599,9 +599,9 @@ The {{TrustedParserOptions/runScripts}} getter steps are to return [=this=]'s as
 <div algorithm>
 The <dfn method for="TrustedParserOptions">sanitizer()</dfn> method steps are:
 
-1. If [=this=]'s [=TrustedParserOptions/sanitizer config=] is null, return null.
+1. If [=this=]'s [=TrustedParserOptions/sanitizer configuration=] is null, return null.
 1. Let |sanitizer| be a new {{Sanitizer}} in [=this=]'s [=relevant realm=].
-1. [=configure a sanitizer|Configure=] |sanitizer| given [=this=]'s [=TrustedParserOptions/sanitizer config=] and true.
+1. [=configure a sanitizer|Configure=] |sanitizer| given [=this=]'s [=TrustedParserOptions/sanitizer configuration=] and true.
 1. Return |sanitizer|.
 
 </div>
@@ -1258,7 +1258,7 @@ a string or dictionary |value| and a list |arguments|, perform the following ste
         from |policy|'s [=relevant realm=] and |policyValue|.
     1.  Let |runScripts| be |policyValue|["runScripts"] [=with default=] false.
     1.  Return a new instance of {{TrustedParserOptions}} in |policy|'s [=relevant realm=] with its
-        [=TrustedParserOptions/sanitizer config=] set to |sanitizerConfig|, and its
+        [=TrustedParserOptions/sanitizer configuration=] set to |sanitizerConfig|, and its
         [=TrustedParserOptions/runScripts=] set to |runScripts|.
 1.  Let |dataString| be the result of stringifying |policyValue|.
 1.  If |policyValue| is null or undefined, set |dataString| to the empty string.
@@ -1314,12 +1314,12 @@ a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions
 1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
 1. If |input| is an instance of {{TrustedHTML}}:
     1. Let |runScripts| be |compliantOptions|'s [=TrustedParserOptions/runScripts=] if |compliantOptions| is an instance of {{TrustedParserOptions}}; otherwise |compliantOptions|["runScripts"], [=with default=] false.
-    1. Let |sanitizerConfig| be |options|'s [=TrustedParserOptions/sanitizer config=] if |options| is an instance of {{TrustedParserOptions}}; otherwise the result of [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from |global|'s [=relevant realm=] and |options|.
-    1. Let |trustedOptions| be a new {{TrustedParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedParserOptions/sanitizer config=] is |sanitizerConfig| and whose [=TrustedParserOptions/runScripts=] is |runScripts|.
+    1. Let |sanitizerConfig| be |options|'s [=TrustedParserOptions/sanitizer configuration=] if |options| is an instance of {{TrustedParserOptions}}; otherwise the result of [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from |global|'s [=relevant realm=] and |options|.
+    1. Let |trustedOptions| be a new {{TrustedParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedParserOptions/sanitizer configuration=] is |sanitizerConfig| and whose [=TrustedParserOptions/runScripts=] is |runScripts|.
     1. Return (stringified |input|, |trustedOptions|).
 1. If |documentType| is `"html"`:
     1. If |options| is an instance of {{TrustedParserOptions}}, return (stringified |input|, |compliantOptions|).
-    1. If |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer config=] is not null:
+    1. If |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer configuration=] is not null:
         1. Return (stringified |input|, |compliantOptions|).
 1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
 1. If the algorithm threw an error, rethrow the error.
@@ -1403,7 +1403,7 @@ a boolean |throwIfMissing|, and a string |sink|:
     It cannot enable script execution when the caller did not request scripts to be executed in the first place.
 
 1. Return a new {{TrustedParserOptions}} in |global|'s [=relevant realm=]
-    whose [=TrustedParserOptions/sanitizer config=] is set to the result of
+    whose [=TrustedParserOptions/sanitizer configuration=] is set to the result of
     [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from
     |global|'s [=relevant realm=] and |policyValue|,
     and whose [=TrustedParserOptions/runScripts=] is set to |runScripts|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1299,7 +1299,7 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
 1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
 1. If |input| is an instance of {{TrustedHTML}}:
     1. Let |runScripts| be |compliantOptions|'s [=TrustedHTMLParserOptions/runScripts=] if |compliantOptions| is an instance of {{TrustedHTMLParserOptions}}; otherwise |compliantOptions|["runScripts"], [=with default=] false.
-    1. Let |sanitizerConfig| be |options|'s [=TrustedHTMLParserOptions/sanitizer configuration=] if |options| is an instance of {{TrustedHTMLParserOptions}}; otherwise the result of [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from |global|'s [=relevant realm=] and |options|.
+    1. Let |sanitizerConfig| be |compliantOptions|'s [=TrustedHTMLParserOptions/sanitizer configuration=] if |compliantOptions| is an instance of {{TrustedHTMLParserOptions}}; otherwise the result of [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from |global|'s [=relevant realm=] and |compliantOptions|.
     1. Let |trustedOptions| be a new {{TrustedHTMLParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedHTMLParserOptions/sanitizer configuration=] is |sanitizerConfig| and whose [=TrustedHTMLParserOptions/runScripts=] is |runScripts|.
     1. Return (stringified |input|, |trustedOptions|).
 1. If |documentType| is `"html"`:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1297,11 +1297,6 @@ To <dfn export>get trusted type compliant input</dfn> given a [=realm/global obj
 a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, a string |sink|, and an optional `"html"` or `"xml"` |documentType| (default `"html"`):
 
 1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
-1. If |input| is an instance of {{TrustedHTML}}:
-    1. Let |runScripts| be |compliantOptions|'s [=TrustedHTMLParserOptions/runScripts=] if |compliantOptions| is an instance of {{TrustedHTMLParserOptions}}; otherwise |compliantOptions|["runScripts"], [=with default=] false.
-    1. Let |sanitizerConfig| be |compliantOptions|'s [=TrustedHTMLParserOptions/sanitizer configuration=] if |compliantOptions| is an instance of {{TrustedHTMLParserOptions}}; otherwise the result of [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from |global|'s [=relevant realm=] and |compliantOptions|.
-    1. Let |trustedOptions| be a new {{TrustedHTMLParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedHTMLParserOptions/sanitizer configuration=] is |sanitizerConfig| and whose [=TrustedHTMLParserOptions/runScripts=] is |runScripts|.
-    1. Return (stringified |input|, |trustedOptions|).
 1. If |documentType| is `"html"`:
     1. If |options| is an instance of {{TrustedHTMLParserOptions}}, return (stringified |input|, |compliantOptions|).
     1. If |compliantOptions| is an instance of {{TrustedHTMLParserOptions}} and |compliantOptions|'s [=TrustedHTMLParserOptions/sanitizer configuration=] is not null:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1178,7 +1178,7 @@ Inject a sanitizer when using an HTML injection sink.
 })();
 </xmp>
 
-Apart from sanitization, the default policy can also prevent an HTML injection from running scripts.
+Apart from sanitization, the default policy can also control whether an HTML injection executes scripts by overriding the caller's {{SetHTMLUnsafeOptions/runScripts}} setting.
 HTML inserted with {{SetHTMLUnsafeOptions/runScripts}} set to false can still insert `script` elements into the document,
 but those scripts are not automatically executed.
 
@@ -1314,7 +1314,6 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <th>|input|</th>
       <th>Default policy state / callback</th>
       <th>Result</th>
-      <th>Effective <code>runScripts</code></th>
       <th>Effective <code>sanitizer</code></th>
       <th>Rationale</th>
     </tr>
@@ -1326,7 +1325,6 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>String or {{TrustedHTML}}</td>
       <td>(Ignored)</td>
       <td>Returns `(stringified |input|, |options|)`.</td>
-      <td>|options|'s [=TrustedHTMLParserOptions/runScripts=]</td>
       <td>|options|'s [=TrustedHTMLParserOptions/sanitizer configuration=]</td>
       <td>Caller-supplied {{TrustedHTMLParserOptions}} explicitly authorizes the parse operation, with script execution and sanitization dictated by the policy that minted it.</td>
     </tr>
@@ -1336,15 +1334,13 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td rowspan="3">{{TrustedHTML}}</td>
       <td>{{TrustedTypePolicyOptions/createParserOptions}} returns a dictionary configuring a policy sanitizer</td>
       <td>Returns `(stringified |input|, |compliantOptions|)`.</td>
-      <td>Caller's `runScripts` clamped by policy</td>
       <td>Configured by {{TrustedTypePolicyOptions/createParserOptions}}</td>
-      <td><strong>Policy vets or replaces caller's sanitizer on TrustedHTML:</strong> Even though |input| is an attested {{TrustedHTML}} instance, {{TrustedTypePolicyOptions/createParserOptions}} runs and receives the caller's sanitizer in `argument["sanitizer"]`. The policy can inspect, enforce, or replace the sanitizer configuration, ensuring unvetted caller-supplied sanitizers cannot bypass policy review.</td>
+      <td><strong>Policy vets or replaces caller's sanitizer on TrustedHTML:</strong> Even though |input| is an attested {{TrustedHTML}} instance, {{TrustedTypePolicyOptions/createParserOptions}} runs and receives the caller's sanitizer in `argument["sanitizer"]`. The policy can inspect, enforce, or replace the sanitizer configuration (as well as control script execution), ensuring unvetted caller-supplied options cannot bypass policy review.</td>
     </tr>
     <tr>
       <td>Dictionary (caller provides `sanitizer`)</td>
       <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `{}` (omits sanitizer)</td>
       <td>Returns `(stringified |input|, |compliantOptions|)`.</td>
-      <td>Caller's `runScripts` clamped by policy</td>
       <td>`null`</td>
       <td><strong>Policy strips caller's sanitizer:</strong> The default policy determines the final parser options. If the policy returns no sanitizer, no sanitization is performed during parsing, overriding the caller's request.</td>
     </tr>
@@ -1352,27 +1348,17 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>Dictionary (with optional `sanitizer`)</td>
       <td>No {{TrustedTypePolicyOptions/createParserOptions}} (or no default policy)</td>
       <td>Returns `(stringified |input|, |options|)`.</td>
-      <td>|options|["runScripts"] (allows `true`)</td>
       <td>|options|["sanitizer"] (if sink accepts dictionary options; null otherwise)</td>
       <td><strong>Unvetted pass-through when no parser policy:</strong> When no policy defines {{TrustedTypePolicyOptions/createParserOptions}}, an existing {{TrustedHTML}} instance satisfies Trusted Types directly (bypassing {{TrustedTypePolicyOptions/createHTML}}). Any caller-supplied dictionary options (including `sanitizer` and `runScripts`) pass through unvetted to the sink.</td>
     </tr>
     <tr>
-      <td rowspan="8">`"html"`</td>
-      <td>Dictionary (`runScripts: false` or omitted)</td>
-      <td rowspan="2">String</td>
-      <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `{ runScripts: true }`</td>
+      <td rowspan="7">`"html"`</td>
+      <td>Dictionary</td>
+      <td>String</td>
+      <td>{{TrustedTypePolicyOptions/createParserOptions}} returns a dictionary</td>
       <td>Returns `(stringified |input|, |compliantOptions|)`.</td>
-      <td>`false`</td>
-      <td>Configured by policy (or null)</td>
-      <td><strong>Default policy cannot enable scripts:</strong> Even if the default policy returns `runScripts: true`, script execution remains `false` because the caller did not request it (`runScriptsInput` is `false`).</td>
-    </tr>
-    <tr>
-      <td>Dictionary (`runScripts: true`)</td>
-      <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `{ runScripts: true }`</td>
-      <td>Returns `(stringified |input|, |compliantOptions|)`.</td>
-      <td>`true`</td>
-      <td>Configured by policy (or null)</td>
-      <td>Parsing is authorized by the policy-supplied options. Scripts execute because both the caller requested it and the default policy allowed it.</td>
+      <td>Configured by {{TrustedTypePolicyOptions/createParserOptions}} (or null)</td>
+      <td><strong>Parsing raw string authorized by parser policy:</strong> The default policy returns compliant parser options, authorizing raw string parsing and configuring sanitization and script execution without requiring {{TrustedTypePolicyOptions/createHTML}}.</td>
     </tr>
     <tr>
       <td rowspan="2">Dictionary</td>
@@ -1380,13 +1366,11 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>{{TrustedTypePolicyOptions/createParserOptions}} throws an exception</td>
       <td>Rethrows the exception.</td>
       <td>N/A</td>
-      <td>N/A</td>
       <td>Exceptions in policy callbacks propagate immediately to the caller, regardless of whether |input| is a string or {{TrustedHTML}}.</td>
     </tr>
     <tr>
       <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `null` or `undefined`</td>
       <td>Throws a {{TypeError}}.</td>
-      <td>N/A</td>
       <td>N/A</td>
       <td>Returning null or undefined from a policy callback rejects the value, triggering a CSP violation error, regardless of whether |input| is a string or {{TrustedHTML}}.</td>
     </tr>
@@ -1395,7 +1379,6 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td rowspan="4">String</td>
       <td>No {{TrustedTypePolicyOptions/createParserOptions}}; {{TrustedTypePolicyOptions/createHTML}} returns {{TrustedHTML}}</td>
       <td>Returns `(stringified |convertedInput|, |options|)`.</td>
-      <td>|options|["runScripts"]</td>
       <td>|options|["sanitizer"] (if sink accepts dictionary options; null otherwise)</td>
       <td>Provides backwards compatibility: when no policy manages parser options, the sink falls back to vetting or sanitizing the markup string via {{TrustedTypePolicyOptions/createHTML}}. Once converted to {{TrustedHTML}}, scripts and caller-supplied sanitizer options apply if requested.</td>
     </tr>
@@ -1403,20 +1386,17 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>No {{TrustedTypePolicyOptions/createParserOptions}}; {{TrustedTypePolicyOptions/createHTML}} throws an exception</td>
       <td>Rethrows the exception.</td>
       <td>N/A</td>
-      <td>N/A</td>
       <td>Exceptions in policy callbacks propagate immediately to the caller.</td>
     </tr>
     <tr>
       <td>No {{TrustedTypePolicyOptions/createParserOptions}}; {{TrustedTypePolicyOptions/createHTML}} returns `null` or `undefined`</td>
       <td>Throws a {{TypeError}}.</td>
       <td>N/A</td>
-      <td>N/A</td>
       <td>Rejection by {{TrustedTypePolicyOptions/createHTML}} triggers a CSP violation error.</td>
     </tr>
     <tr>
       <td>No default policy (or neither callback defined)</td>
       <td>Throws a {{TypeError}}.</td>
-      <td>N/A</td>
       <td>N/A</td>
       <td>Under enforcing CSP, a raw string cannot be parsed without a policy authorizing either the parser options or the markup string.</td>
     </tr>
@@ -1426,7 +1406,6 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>{{TrustedHTML}}</td>
       <td>(Any)</td>
       <td>Returns `(stringified |input|, |options|)`.</td>
-      <td>`false`</td>
       <td>None (ignored)</td>
       <td>XML sinks require trusted markup; a {{TrustedHTML}} instance satisfies this requirement directly. XML fragment parsing does not support sanitization and never executes scripts.</td>
     </tr>
@@ -1436,7 +1415,6 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td rowspan="3">String</td>
       <td>{{TrustedTypePolicyOptions/createHTML}} returns {{TrustedHTML}}</td>
       <td>Returns `(stringified |convertedInput|, |options|)`.</td>
-      <td>`false`</td>
       <td>None (ignored)</td>
       <td>XML fragment sinks do not support parser options bypass or sanitization; markup strings must always be converted via {{TrustedTypePolicyOptions/createHTML}}. XML fragment parsing does not support sanitization and never executes scripts.</td>
     </tr>
@@ -1444,13 +1422,11 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>{{TrustedTypePolicyOptions/createHTML}} throws an exception</td>
       <td>Rethrows the exception.</td>
       <td>N/A</td>
-      <td>N/A</td>
       <td>Exceptions in policy callbacks propagate immediately to the caller.</td>
     </tr>
     <tr>
       <td>No {{TrustedTypePolicyOptions/createHTML}} or no default policy (or returns `null`/`undefined`)</td>
       <td>Throws a {{TypeError}}.</td>
-      <td>N/A</td>
       <td>N/A</td>
       <td>Untrusted strings cannot be injected into XML sinks without {{TrustedTypePolicyOptions/createHTML}}, regardless of parser options.</td>
     </tr>
@@ -1460,8 +1436,8 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
 <div class="note">
 <p><strong>TrustedHTML, runScripts, and sanitization:</strong> Sinks enforcing Trusted Types handle options and scripts as follows:</p>
 <ul>
-  <li>When |input| is a {{TrustedHTML}} instance, a default policy's {{TrustedTypePolicyOptions/createParserOptions}} still vets any caller-supplied options dictionary, allowing the policy to inspect, configure, or override the sanitizer configuration (and clamp script execution) despite the input already being {{TrustedHTML}}. If {{TrustedTypePolicyOptions/createParserOptions}} throws or returns `null` or `undefined`, the operation is rejected. Only when {{TrustedTypePolicyOptions/createParserOptions}} is absent do the caller's dictionary options pass through unvetted.</li>
-  <li>When |options| is a {{TrustedHTMLParserOptions}}, script execution and sanitization are governed by the policy that created the options object. A default policy's {{TrustedTypePolicyOptions/createParserOptions}} can only clamp script execution to `false`; it can never enable scripts if the caller did not request them (`runScriptsInput` is `false`).</li>
+  <li>When |input| is a {{TrustedHTML}} instance, a default policy's {{TrustedTypePolicyOptions/createParserOptions}} still vets any caller-supplied options dictionary, allowing the policy to inspect, configure, or override the sanitizer configuration (as well as control script execution) despite the input already being {{TrustedHTML}}. If {{TrustedTypePolicyOptions/createParserOptions}} throws or returns `null` or `undefined`, the operation is rejected. Only when {{TrustedTypePolicyOptions/createParserOptions}} is absent do the caller's dictionary options pass through unvetted.</li>
+  <li>When |options| is a {{TrustedHTMLParserOptions}}, script execution and sanitization are governed by the policy that created the options object. When options are passed as a dictionary, a default policy's {{TrustedTypePolicyOptions/createParserOptions}} determines the final script execution behavior, overriding the caller's requested `runScripts` setting.</li>
   <li>XML fragment parsing does not support sanitization and never executes scripts; any sanitizer configuration or `runScripts` flag is ignored for XML sinks.</li>
   <li>In report-only mode or when Trusted Types enforcement is not required for the sink, a {{TypeError}} is not thrown on violation; instead, the original stringified |input| and |options| are returned.</li>
   <li>For streaming HTML fragment parsing, [=get trusted type compliant parser options=] is invoked directly with |throwIfMissing| set to true. In that context, if {{TrustedTypePolicyOptions/createParserOptions}} is missing, throws, or returns `null` or `undefined`, a {{TypeError}} is thrown (or rethrown) immediately.</li>
@@ -1541,10 +1517,9 @@ a boolean |throwIfMissing|, and a string |sink|:
         Note: This step assures that the default policy rejection will be reported, but ignored in a report-only mode.
 
     1. Throw a {{TypeError}}.
-1. Let |runScripts| be true if |policyValue|["runScripts"] is true and |runScriptsInput| is true; otherwise false.
+1. Let |runScripts| be |policyValue|["runScripts"], [=with default=] false.
 
-    Note: When invoked as a default policy, the {{TrustedTypePolicyOptions/createParserOptions}} callback can only disable script execution.
-    It cannot enable script execution when the caller did not request scripts to be executed in the first place.
+    Note: When invoked as a default policy, the {{TrustedTypePolicyOptions/createParserOptions}} callback determines the final script execution behavior, overriding the caller's requested `runScripts` option.
 
 1. Return a new {{TrustedHTMLParserOptions}} in |global|'s [=relevant realm=]
     whose [=TrustedHTMLParserOptions/sanitizer configuration=] is set to the result of

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -573,9 +573,9 @@ The value is set when the object is created, and will never change during its li
 <dfn for="TrustedScriptURL">stringification behavior</dfn> steps of a
 TrustedScriptURL object are to return the associated [=TrustedScriptURL/data=] value.
 
-### <dfn interface>TrustedParserOptions</dfn> ### {#trusted-parser-options}
+### <dfn interface>TrustedHTMLParserOptions</dfn> ### {#trusted-html-parser-options}
 
-The {{TrustedParserOptions}} interface represents options that a developer
+The {{TrustedHTMLParserOptions}} interface represents options that a developer
 can confidently pass into an [=injection sink=] that will parse HTML.
 These objects are immutable wrappers around a
 {{SetHTMLUnsafeOptions}} dictionary, constructed via a {{TrustedTypePolicy}}'s
@@ -583,28 +583,13 @@ These objects are immutable wrappers around a
 
 <pre class="idl">
 [Exposed=Window]
-interface TrustedParserOptions {
-  [NewObject] Sanitizer? sanitizer();
-  readonly attribute boolean runScripts;
+interface TrustedHTMLParserOptions {
 };
 </pre>
 
-{{TrustedParserOptions}} objects have an associated boolean <dfn export for="TrustedParserOptions">runScripts</dfn>
-and an associated {{SanitizerConfig}}-or-null <dfn export for="TrustedParserOptions">sanitizer configuration</dfn>.
+{{TrustedHTMLParserOptions}} objects have an associated boolean <dfn export for="TrustedHTMLParserOptions">runScripts</dfn>
+and an associated {{SanitizerConfig}}-or-null <dfn export for="TrustedHTMLParserOptions">sanitizer configuration</dfn>.
 These values are set when the object is created, and will never change during its lifetime.
-
-The {{TrustedParserOptions/runScripts}} getter steps are to return [=this=]'s associated
-[=TrustedParserOptions/runScripts=].
-
-<div algorithm>
-The <dfn method for="TrustedParserOptions">sanitizer()</dfn> method steps are:
-
-1. If [=this=]'s [=TrustedParserOptions/sanitizer configuration=] is null, return null.
-1. Let |sanitizer| be a new {{Sanitizer}} in [=this=]'s [=relevant realm=].
-1. [=configure a sanitizer|Configure=] |sanitizer| given [=this=]'s [=TrustedParserOptions/sanitizer configuration=] and true.
-1. Return |sanitizer|.
-
-</div>
 
 ## <dfn>Policies</dfn> ## {#policies-hdr}
 
@@ -973,7 +958,7 @@ interface TrustedTypePolicy {
   TrustedHTML createHTML(DOMString input, any... arguments);
   TrustedScript createScript(DOMString input, any... arguments);
   TrustedScriptURL createScriptURL(DOMString input, any... arguments);
-  [Exposed=Window] TrustedParserOptions createParserOptions(optional SetHTMLUnsafeOptions options = {}, any... arguments);
+  [Exposed=Window] TrustedHTMLParserOptions createParserOptions(optional SetHTMLUnsafeOptions options = {}, any... arguments);
 };
 </pre>
 
@@ -1037,7 +1022,7 @@ Each TrustedTypePolicy object has an associated {{TrustedTypePolicyOptions}} <df
       <dt>policy</dt>
       <dd>[=this=] value</dd>
       <dt>trustedTypeName</dt>
-      <dd>`"TrustedParserOptions"`</dd>
+      <dd>`"TrustedHTMLParserOptions"`</dd>
       <dt>value</dt>
       <dd>options</dd>
       <dt>arguments</dt>
@@ -1251,15 +1236,15 @@ a string or dictionary |value| and a list |arguments|, perform the following ste
 
 1.  Let |policyValue| be the result of executing [=get trusted type policy value=] with the same arguments as this algorithm and additionally true as |throwIfMissing|.
 1.  If the algorithm threw an error, rethrow the error and abort the following steps.
-1.  If |trustedTypeName| is `"TrustedParserOptions"`:
+1.  If |trustedTypeName| is `"TrustedHTMLParserOptions"`:
     1.  If |policyValue| is not a [=dictionary=], throw a {{TypeError}}.
     1.  Let |sanitizerConfig| be the result of
         [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=]
         from |policy|'s [=relevant realm=] and |policyValue|.
     1.  Let |runScripts| be |policyValue|["runScripts"] [=with default=] false.
-    1.  Return a new instance of {{TrustedParserOptions}} in |policy|'s [=relevant realm=] with its
-        [=TrustedParserOptions/sanitizer configuration=] set to |sanitizerConfig|, and its
-        [=TrustedParserOptions/runScripts=] set to |runScripts|.
+    1.  Return a new instance of {{TrustedHTMLParserOptions}} in |policy|'s [=relevant realm=] with its
+        [=TrustedHTMLParserOptions/sanitizer configuration=] set to |sanitizerConfig|, and its
+        [=TrustedHTMLParserOptions/runScripts=] set to |runScripts|.
 1.  Let |dataString| be the result of stringifying |policyValue|.
 1.  If |policyValue| is null or undefined, set |dataString| to the empty string.
 1.  Return a new instance of an interface with a type
@@ -1292,7 +1277,7 @@ a string or dictionary |value|, a list |arguments|, and a boolean |throwIfMissin
       </tr>
       <tr>
         <td>"createParserOptions"</td>
-        <td>"TrustedParserOptions"</td>
+        <td>"TrustedHTMLParserOptions"</td>
       </tr>
     </table>
 
@@ -1309,17 +1294,17 @@ a string or dictionary |value|, a list |arguments|, and a boolean |throwIfMissin
 ## Get Trusted Type compliant input ## {#get-trusted-type-compliant-input-algorithm}
 
 To <dfn export>get trusted type compliant input</dfn> given a [=realm/global object=] |global|, a string or {{TrustedHTML}} |input|,
-a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, a string |sink|, and an optional `"html"` or `"xml"` |documentType| (default `"html"`):
+a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, a string |sink|, and an optional `"html"` or `"xml"` |documentType| (default `"html"`):
 
 1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
 1. If |input| is an instance of {{TrustedHTML}}:
-    1. Let |runScripts| be |compliantOptions|'s [=TrustedParserOptions/runScripts=] if |compliantOptions| is an instance of {{TrustedParserOptions}}; otherwise |compliantOptions|["runScripts"], [=with default=] false.
-    1. Let |sanitizerConfig| be |options|'s [=TrustedParserOptions/sanitizer configuration=] if |options| is an instance of {{TrustedParserOptions}}; otherwise the result of [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from |global|'s [=relevant realm=] and |options|.
-    1. Let |trustedOptions| be a new {{TrustedParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedParserOptions/sanitizer configuration=] is |sanitizerConfig| and whose [=TrustedParserOptions/runScripts=] is |runScripts|.
+    1. Let |runScripts| be |compliantOptions|'s [=TrustedHTMLParserOptions/runScripts=] if |compliantOptions| is an instance of {{TrustedHTMLParserOptions}}; otherwise |compliantOptions|["runScripts"], [=with default=] false.
+    1. Let |sanitizerConfig| be |options|'s [=TrustedHTMLParserOptions/sanitizer configuration=] if |options| is an instance of {{TrustedHTMLParserOptions}}; otherwise the result of [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from |global|'s [=relevant realm=] and |options|.
+    1. Let |trustedOptions| be a new {{TrustedHTMLParserOptions}} in |global|'s [=relevant realm=] whose [=TrustedHTMLParserOptions/sanitizer configuration=] is |sanitizerConfig| and whose [=TrustedHTMLParserOptions/runScripts=] is |runScripts|.
     1. Return (stringified |input|, |trustedOptions|).
 1. If |documentType| is `"html"`:
-    1. If |options| is an instance of {{TrustedParserOptions}}, return (stringified |input|, |compliantOptions|).
-    1. If |compliantOptions| is an instance of {{TrustedParserOptions}} and |compliantOptions|'s [=TrustedParserOptions/sanitizer configuration=] is not null:
+    1. If |options| is an instance of {{TrustedHTMLParserOptions}}, return (stringified |input|, |compliantOptions|).
+    1. If |compliantOptions| is an instance of {{TrustedHTMLParserOptions}} and |compliantOptions|'s [=TrustedHTMLParserOptions/sanitizer configuration=] is not null:
         1. Return (stringified |input|, |compliantOptions|).
 1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
 1. If the algorithm threw an error, rethrow the error.
@@ -1357,10 +1342,10 @@ Note: |throwIfMissing| is false when called from [=get trusted type compliant in
 When streaming or in contexts where the HTML string cannot be validated up front, callers pass true for |throwIfMissing| to ensure a default policy with {{TrustedTypePolicyOptions/createParserOptions}} is required.
 
 To <dfn export>get trusted type compliant parser options</dfn> given a [=realm/global object=] |global|,
-|input|, which is either a {{TrustedParserOptions}}, a {{SetHTMLUnsafeOptions}}, or a {{ParseHTMLUnsafeOptions}},
+|input|, which is either a {{TrustedHTMLParserOptions}}, a {{SetHTMLUnsafeOptions}}, or a {{ParseHTMLUnsafeOptions}},
 a boolean |throwIfMissing|, and a string |sink|:
 
-1.  If |input| is an instance of {{TrustedParserOptions}}, return |input|.
+1.  If |input| is an instance of {{TrustedHTMLParserOptions}}, return |input|.
 1.  Let |requireTrustedTypes| be the result of executing [=Does sink type require trusted types?=] algorithm,
     passing |global|, `"script"`, and true.
 1.  If |requireTrustedTypes| is `false`, return |input|.
@@ -1387,7 +1372,7 @@ a boolean |throwIfMissing|, and a string |sink|:
     1. Let |sanitizerInput| be a new {{Sanitizer}} in |global|'s [=relevant realm=].
     1. [=configure a sanitizer|Configure=] |sanitizerInput| given |sanitizerInputConfig| and true.
     1. Set |argument|["sanitizer"] to |sanitizerInput|.
-1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument|, "TrustedParserOptions", |sink| » and `"rethrow"`.
+1. Let |policyValue| be the result of [=invoke|invoking=] |function| with « |argument|, "TrustedHTMLParserOptions", |sink| » and `"rethrow"`.
 1. If the algorithm threw an error, rethrow the error and abort the following steps.
 1. If |policyValue| is `null` or `undefined`:
     1. Let |disposition| be the result of executing [=should sink type mismatch violation be blocked by content security policy?=] algorithm,
@@ -1402,11 +1387,11 @@ a boolean |throwIfMissing|, and a string |sink|:
     Note: When invoked as a default policy, the {{TrustedTypePolicyOptions/createParserOptions}} callback can only disable script execution.
     It cannot enable script execution when the caller did not request scripts to be executed in the first place.
 
-1. Return a new {{TrustedParserOptions}} in |global|'s [=relevant realm=]
-    whose [=TrustedParserOptions/sanitizer configuration=] is set to the result of
+1. Return a new {{TrustedHTMLParserOptions}} in |global|'s [=relevant realm=]
+    whose [=TrustedHTMLParserOptions/sanitizer configuration=] is set to the result of
     [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from
     |global|'s [=relevant realm=] and |policyValue|,
-    and whose [=TrustedParserOptions/runScripts=] is set to |runScripts|.
+    and whose [=TrustedHTMLParserOptions/runScripts=] is set to |runScripts|.
 
 To <dfn>get a sanitizer config copy from dictionary</dfn> given a [=realm=] |realm| and a dictionary |dictionary|:
 1. Let |sanitizerInput| be |dictionary|["sanitizer"], [=with default|defaulting to=] null.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1313,6 +1313,7 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <th>|input|</th>
       <th>Default policy state / callback</th>
       <th>Result</th>
+      <th>Effective <code>runScripts</code></th>
       <th>Rationale</th>
     </tr>
   </thead>
@@ -1323,33 +1324,53 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>String or {{TrustedHTML}}</td>
       <td>(Ignored)</td>
       <td>Returns `(stringified |input|, |options|)`.</td>
-      <td>Caller-supplied {{TrustedHTMLParserOptions}} explicitly authorizes the parse operation, satisfying Trusted Types for the sink.</td>
+      <td>|options|'s [=TrustedHTMLParserOptions/runScripts=]</td>
+      <td>Caller-supplied {{TrustedHTMLParserOptions}} explicitly authorizes the parse operation, with script execution dictated by the policy that minted it.</td>
     </tr>
     <tr>
-      <td rowspan="3">`"html"`</td>
-      <td rowspan="3">Dictionary</td>
-      <td rowspan="3">String or {{TrustedHTML}}</td>
-      <td>{{TrustedTypePolicyOptions/createParserOptions}} returns a dictionary</td>
+      <td rowspan="5">`"html"`</td>
+      <td>Dictionary (`runScripts: false` or omitted)</td>
+      <td rowspan="5">String or {{TrustedHTML}}</td>
+      <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `{ runScripts: true }`</td>
       <td>Returns `(stringified |input|, |compliantOptions|)`.</td>
-      <td>The default policy creates a {{TrustedHTMLParserOptions}} to configure the parser (such as setting a sanitizer or disable script execution), authorizing the sink.</td>
+      <td>`false`</td>
+      <td><strong>Default policy cannot enable scripts:</strong> Even if the default policy returns `runScripts: true`, script execution remains `false` because the caller did not request it (`runScriptsInput` is `false`).</td>
     </tr>
     <tr>
+      <td>Dictionary (`runScripts: true`)</td>
+      <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `{ runScripts: false }`</td>
+      <td>Returns `(stringified |input|, |compliantOptions|)`.</td>
+      <td>`false`</td>
+      <td><strong>Default policy disables scripts:</strong> The default policy overrides the caller's request, disallowing script execution.</td>
+    </tr>
+    <tr>
+      <td>Dictionary (`runScripts: true`)</td>
+      <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `{ runScripts: true }`</td>
+      <td>Returns `(stringified |input|, |compliantOptions|)`.</td>
+      <td>`true`</td>
+      <td>Scripts are permitted to execute because both the caller requested it and the default policy allowed it.</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Dictionary</td>
       <td>{{TrustedTypePolicyOptions/createParserOptions}} throws an exception</td>
       <td>Rethrows the exception.</td>
+      <td>N/A</td>
       <td>Exceptions in policy callbacks propagate immediately to the caller.</td>
     </tr>
     <tr>
       <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `null` or `undefined`</td>
       <td>Throws a {{TypeError}}.</td>
+      <td>N/A</td>
       <td>Returning null or undefined from a policy callback rejects the value, triggering a CSP violation error.</td>
     </tr>
-    <tr>
+    <tr class="highlight">
       <td>`"html"`</td>
       <td>Dictionary</td>
       <td>{{TrustedHTML}}</td>
       <td>No {{TrustedTypePolicyOptions/createParserOptions}} (or no default policy)</td>
       <td>Returns `(stringified |input|, |options|)`.</td>
-      <td>When options are not vetted by a policy, the sink checks the markup; an existing {{TrustedHTML}} instance satisfies this check.</td>
+      <td>|options|["runScripts"] (allows `true`)</td>
+      <td><strong>TrustedHTML + runScripts:</strong> Because |input| is an attested {{TrustedHTML}} instance, scripts are permitted to execute if requested by the caller (e.g. in {{Range/createContextualFragment()}} or {{Element/setHTMLUnsafe()}} with `runScripts: true`).</td>
     </tr>
     <tr>
       <td rowspan="4">`"html"`</td>
@@ -1357,21 +1378,25 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td rowspan="4">String</td>
       <td>No {{TrustedTypePolicyOptions/createParserOptions}}; {{TrustedTypePolicyOptions/createHTML}} returns {{TrustedHTML}}</td>
       <td>Returns `(stringified |convertedInput|, |options|)`.</td>
-      <td>Provides backwards compatibility: when no policy manages parser options, the sink falls back to vetting or sanitizing the markup string via {{TrustedTypePolicyOptions/createHTML}}.</td>
+      <td>|options|["runScripts"]</td>
+      <td>Provides backwards compatibility: when no policy manages parser options, the sink falls back to vetting or sanitizing the markup string via {{TrustedTypePolicyOptions/createHTML}}. Once converted to {{TrustedHTML}}, scripts execute if requested.</td>
     </tr>
     <tr>
       <td>No {{TrustedTypePolicyOptions/createParserOptions}}; {{TrustedTypePolicyOptions/createHTML}} throws an exception</td>
       <td>Rethrows the exception.</td>
+      <td>N/A</td>
       <td>Exceptions in policy callbacks propagate immediately to the caller.</td>
     </tr>
     <tr>
       <td>No {{TrustedTypePolicyOptions/createParserOptions}}; {{TrustedTypePolicyOptions/createHTML}} returns `null` or `undefined`</td>
       <td>Throws a {{TypeError}}.</td>
+      <td>N/A</td>
       <td>Rejection by {{TrustedTypePolicyOptions/createHTML}} triggers a CSP violation error.</td>
     </tr>
     <tr>
       <td>No default policy (or neither callback defined)</td>
       <td>Throws a {{TypeError}}.</td>
+      <td>N/A</td>
       <td>Under enforcing CSP, a raw string cannot be parsed without a policy authorizing either the parser options or the markup string.</td>
     </tr>
     <tr>
@@ -1380,7 +1405,8 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>{{TrustedHTML}}</td>
       <td>(Any)</td>
       <td>Returns `(stringified |input|, |options|)`.</td>
-      <td>XML sinks require trusted markup; a {{TrustedHTML}} instance satisfies this requirement directly.</td>
+      <td>`false`</td>
+      <td>XML sinks require trusted markup; a {{TrustedHTML}} instance satisfies this requirement directly. XML fragment parsing never executes scripts.</td>
     </tr>
     <tr>
       <td rowspan="3">`"xml"`</td>
@@ -1388,23 +1414,33 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td rowspan="3">String</td>
       <td>{{TrustedTypePolicyOptions/createHTML}} returns {{TrustedHTML}}</td>
       <td>Returns `(stringified |convertedInput|, |options|)`.</td>
-      <td>XML fragment sinks do not support parser options bypass or sanitization; markup strings must always be converted via {{TrustedTypePolicyOptions/createHTML}}.</td>
+      <td>`false`</td>
+      <td>XML fragment sinks do not support parser options bypass or sanitization; markup strings must always be converted via {{TrustedTypePolicyOptions/createHTML}}. XML fragment parsing never executes scripts.</td>
     </tr>
     <tr>
       <td>{{TrustedTypePolicyOptions/createHTML}} throws an exception</td>
       <td>Rethrows the exception.</td>
+      <td>N/A</td>
       <td>Exceptions in policy callbacks propagate immediately to the caller.</td>
     </tr>
     <tr>
       <td>No {{TrustedTypePolicyOptions/createHTML}} or no default policy (or returns `null`/`undefined`)</td>
       <td>Throws a {{TypeError}}.</td>
+      <td>N/A</td>
       <td>Untrusted strings cannot be injected into XML sinks without {{TrustedTypePolicyOptions/createHTML}}, regardless of parser options.</td>
     </tr>
   </tbody>
 </table>
 
-<p class="note">In report-only mode or when Trusted Types enforcement is not required for the sink, a {{TypeError}} is not thrown on violation; instead, the original stringified |input| and |options| are returned.<br>
-For streaming HTML fragment parsing, [=get trusted type compliant parser options=] is invoked directly with |throwIfMissing| set to true. In that context, if {{TrustedTypePolicyOptions/createParserOptions}} is missing, throws, or returns `null` or `undefined`, a {{TypeError}} is thrown (or rethrown) immediately.</p>
+<div class="note">
+<p><strong>TrustedHTML + runScripts:</strong> Script execution is permitted only when the markup is attested as safe by a policy. Specifically:</p>
+<ul>
+  <li>When |input| is a {{TrustedHTML}} instance (or converted into one by {{TrustedTypePolicyOptions/createHTML}}), scripts are allowed to execute if requested by the caller (such as {{Element/setHTMLUnsafe()}} with `runScripts: true`).</li>
+  <li>When |options| is a {{TrustedHTMLParserOptions}}, script execution is governed by the policy that created the options object. A default policy's {{TrustedTypePolicyOptions/createParserOptions}} can only clamp script execution to `false`; it can never enable scripts if the caller did not request them (`runScriptsInput` is `false`).</li>
+  <li>In report-only mode or when Trusted Types enforcement is not required for the sink, a {{TypeError}} is not thrown on violation; instead, the original stringified |input| and |options| are returned.</li>
+  <li>For streaming HTML fragment parsing, [=get trusted type compliant parser options=] is invoked directly with |throwIfMissing| set to true. In that context, if {{TrustedTypePolicyOptions/createParserOptions}} is missing, throws, or returns `null` or `undefined`, a {{TypeError}} is thrown (or rethrown) immediately.</li>
+</ul>
+</div>
 
 ## Get Trusted Type compliant string ## {#get-trusted-type-compliant-string-algorithm}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1304,7 +1304,8 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
 1. If the algorithm threw an error, rethrow the error.
 1. Return (|compliantHTML|, |compliantOptions|).
 
-<p class="note">The following table summarizes the behavior of [=get trusted type compliant input=] for various combinations of arguments and default policy callbacks under enforcing Content Security Policy:</p>
+<div class="note">
+<p>The following table summarizes the behavior of [=get trusted type compliant input=] for various combinations of arguments and default policy callbacks under enforcing Content Security Policy:</p>
 
 <table class="data">
   <thead>
@@ -1348,7 +1349,7 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td>Dictionary (with optional `sanitizer`)</td>
       <td>No {{TrustedTypePolicyOptions/createParserOptions}} (or no default policy)</td>
       <td>Returns `(stringified |input|, |options|)`.</td>
-      <td>|options|["sanitizer"] (if sink accepts dictionary options; null otherwise)</td>
+      <td>|options|["sanitizer"] (defaulting to null)</td>
       <td><strong>Unvetted pass-through when no parser policy:</strong> When no policy defines {{TrustedTypePolicyOptions/createParserOptions}}, an existing {{TrustedHTML}} instance satisfies Trusted Types directly (bypassing {{TrustedTypePolicyOptions/createHTML}}). Any caller-supplied dictionary options (including `sanitizer` and `runScripts`) pass through unvetted to the sink.</td>
     </tr>
     <tr>
@@ -1379,7 +1380,7 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
       <td rowspan="4">String</td>
       <td>No {{TrustedTypePolicyOptions/createParserOptions}}; {{TrustedTypePolicyOptions/createHTML}} returns {{TrustedHTML}}</td>
       <td>Returns `(stringified |convertedInput|, |options|)`.</td>
-      <td>|options|["sanitizer"] (if sink accepts dictionary options; null otherwise)</td>
+      <td>|options|["sanitizer"] (defaulting to null)</td>
       <td>Provides backwards compatibility: when no policy manages parser options, the sink falls back to vetting or sanitizing the markup string via {{TrustedTypePolicyOptions/createHTML}}. Once converted to {{TrustedHTML}}, scripts and caller-supplied sanitizer options apply if requested.</td>
     </tr>
     <tr>
@@ -1433,7 +1434,6 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
   </tbody>
 </table>
 
-<div class="note">
 <p><strong>TrustedHTML, runScripts, and sanitization:</strong> Sinks enforcing Trusted Types handle options and scripts as follows:</p>
 <ul>
   <li>When |input| is a {{TrustedHTML}} instance, a default policy's {{TrustedTypePolicyOptions/createParserOptions}} still vets any caller-supplied options dictionary, allowing the policy to inspect, configure, or override the sanitizer configuration (as well as control script execution) despite the input already being {{TrustedHTML}}. If {{TrustedTypePolicyOptions/createParserOptions}} throws or returns `null` or `undefined`, the operation is rejected. Only when {{TrustedTypePolicyOptions/createParserOptions}} is absent do the caller's dictionary options pass through unvetted.</li>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -732,9 +732,6 @@ Note: When enforcing Trusted Types on HTML injection sinks that parse markup (su
 without requiring {{TrustedTypePolicyOptions/createHTML}} or a {{TrustedHTML}} instance. For string-only injection sinks that do not support parser options
 (such as {{HTMLIFrameElement/srcdoc}} or `document.write()`), raw strings must still be converted via {{TrustedTypePolicyOptions/createHTML}}.
 
-Note: When used in legacy HTML injection sinks such as {{Element/innerHTML}}, the `sanitizer` option is only supported for HTML documents.
-When protecting XML documents using legacy sinks, authors are advised to use `createHTML` instead.
-
 ### <dfn interface>TrustedTypePolicyFactory</dfn> ### {#trusted-type-policy-factory}
 
 TrustedTypePolicyFactory creates
@@ -1034,7 +1031,7 @@ Each TrustedTypePolicy object has an associated {{TrustedTypePolicyOptions}} <df
 
 : <dfn>createParserOptions(options, ...arguments)</dfn>
 ::  Returns the
-    result of executing the [=Create a Trusted Type=] algorithm, with the
+    result of executing the [=create a trusted type=] algorithm, with the
     following arguments:
     <dl>
       <dt>policy</dt>
@@ -1315,7 +1312,6 @@ To <dfn export>get trusted type compliant input</dfn> given a [=realm/global obj
 a {{TrustedParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, a string |sink|, and an optional `"html"` or `"xml"` |documentType| (default `"html"`):
 
 1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
-1. If the algorithm threw an error, rethrow the error.
 1. If |input| is an instance of {{TrustedHTML}}:
     1. Let |runScripts| be |compliantOptions|'s [=TrustedParserOptions/runScripts=] if |compliantOptions| is an instance of {{TrustedParserOptions}}; otherwise |compliantOptions|["runScripts"], [=with default=] false.
     1. Let |sanitizerConfig| be |options|'s [=TrustedParserOptions/sanitizer config=] if |options| is an instance of {{TrustedParserOptions}}; otherwise the result of [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=] from |global|'s [=relevant realm=] and |options|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1341,8 +1341,7 @@ The following table summarizes the behavior of [=get trusted type compliant inpu
 <ul>
   <li>When |input| is a {{TrustedHTML}} instance, a default policy's {{TrustedTypePolicyOptions/createParserOptions}} still vets any caller-supplied options dictionary, allowing the policy to inspect, configure, or override the sanitizer configuration (as well as control script execution) despite the input already being {{TrustedHTML}}. If {{TrustedTypePolicyOptions/createParserOptions}} throws or returns `null` or `undefined`, the operation is rejected. Only when {{TrustedTypePolicyOptions/createParserOptions}} is absent do the caller's dictionary options pass through unvetted.</li>
   <li>When |options| is a {{TrustedHTMLParserOptions}}, script execution and sanitization are governed by the policy that created the options object. When options are passed as a dictionary, a default policy's {{TrustedTypePolicyOptions/createParserOptions}} determines the final script execution behavior, overriding the caller's requested `runScripts` setting.</li>
-  <li>XML fragment parsing does not support sanitization and never executes scripts; any sanitizer configuration or `runScripts` flag is ignored for XML sinks.</li>
-  <li>In report-only mode or when Trusted Types enforcement is not required for the sink, a {{TypeError}} is not thrown on violation; instead, the original stringified |input| and |options| are returned.</li>
+  <li>XML fragment parsing does not support sanitization; any sanitizer configuration is ignored for XML sinks.</li>
   <li>For streaming HTML fragment parsing, [=get trusted type compliant parser options=] is invoked directly with |throwIfMissing| set to true. In that context, if {{TrustedTypePolicyOptions/createParserOptions}} is missing, throws, or returns `null` or `undefined`, a {{TypeError}} is thrown (or rethrown) immediately.</li>
 </ul>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -713,9 +713,9 @@ using the built-in sanitizer API.
 </div>
 
 Note: When enforcing Trusted Types on HTML injection sinks that parse markup (such as {{Element/setHTMLUnsafe()}} or {{Element/innerHTML}}),
-{{TrustedTypePolicyOptions/createParserOptions}} returning a non-null sanitizer configuration allows raw strings to be parsed and sanitized directly,
-without requiring {{TrustedTypePolicyOptions/createHTML}} or a {{TrustedHTML}} instance. For string-only injection sinks that do not support parser options
-(such as {{HTMLIFrameElement/srcdoc}} or `document.write()`), raw strings must still be converted via {{TrustedTypePolicyOptions/createHTML}}.
+a {{TrustedHTMLParserOptions}} object (obtained from {{TrustedTypePolicyOptions/createParserOptions}} or provided by a default policy) allows raw strings to be parsed directly,
+without requiring {{TrustedTypePolicyOptions/createHTML}} or a {{TrustedHTML}} instance. Policy authors typically configure a sanitizer in {{TrustedTypePolicyOptions/createParserOptions}} so that untrusted markup is sanitized during parsing. For string-only injection sinks that do not support parser options
+(such as {{HTMLIFrameElement/srcdoc}} or `document.write()`), or for XML documents, raw strings must still be converted via {{TrustedTypePolicyOptions/createHTML}}.
 
 ### <dfn interface>TrustedTypePolicyFactory</dfn> ### {#trusted-type-policy-factory}
 
@@ -1298,9 +1298,7 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
 
 1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
 1. If |documentType| is `"html"`:
-    1. If |options| is an instance of {{TrustedHTMLParserOptions}}, return (stringified |input|, |compliantOptions|).
-    1. If |compliantOptions| is an instance of {{TrustedHTMLParserOptions}} and |compliantOptions|'s [=TrustedHTMLParserOptions/sanitizer configuration=] is not null:
-        1. Return (stringified |input|, |compliantOptions|).
+    1. If |compliantOptions| is an instance of {{TrustedHTMLParserOptions}}, return (stringified |input|, |compliantOptions|).
 1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
 1. If the algorithm threw an error, rethrow the error.
 1. Return (|compliantHTML|, |compliantOptions|).
@@ -1333,8 +1331,9 @@ To <dfn export>get trusted type compliant string</dfn> a {{TrustedType}} type (|
 
 ## Get Trusted Type compliant parser options ## {#get-trusted-type-compliant-parser-options-algorithm}
 
-Note: |throwIfMissing| is false when called from [=get trusted type compliant input=]. For synchronous fragment injection sinks, a valid sanitizer configuration in the resulting options can satisfy Trusted Types enforcement without requiring {{TrustedTypePolicyOptions/createHTML}} on the input string.
+Note: |throwIfMissing| is false when called from [=get trusted type compliant input=]. For synchronous HTML fragment injection sinks, a {{TrustedHTMLParserOptions}} in the resulting options can satisfy Trusted Types enforcement without requiring {{TrustedTypePolicyOptions/createHTML}} on the input string.
 When streaming or in contexts where the HTML string cannot be validated up front, callers pass true for |throwIfMissing| to ensure a default policy with {{TrustedTypePolicyOptions/createParserOptions}} is required.
+For XML documents, parser options cannot satisfy Trusted Types enforcement; XML fragment sinks always require compliant string input via [=get trusted type compliant string=].
 
 To <dfn export>get trusted type compliant parser options</dfn> given a [=realm/global object=] |global|,
 |input|, which is either a {{TrustedHTMLParserOptions}}, a {{SetHTMLUnsafeOptions}}, or a {{ParseHTMLUnsafeOptions}},

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1204,108 +1204,11 @@ but those scripts are not automatically executed.
 
 </div>
 
-# Algorithms # {#algorithms}
+### Summary of input enforcement ### {#summary-of-input-enforcement}
 
-## Create a Trusted Type Policy ## {#create-trusted-type-policy-algorithm}
+*This section is not normative.*
 
-To <dfn>create a trusted type policy</dfn>, given a {{TrustedTypePolicyFactory}} (|factory|),
-a string (|policyName|), {{TrustedTypePolicyOptions}} dictionary (|options|), and a
-[=realm/global object=] (|global|) run these steps:
-
-1.  Let |allowedByCSP| be the result of executing [=should Trusted Type policy
-    creation be blocked by content security policy?=] algorithm with |global|,
-    |policyName| and |factory|'s [=created policy names=] value.
-1.  If |allowedByCSP| is `"Blocked"`, throw a TypeError and abort further steps.
-1.  If |policyName| is `default` and the |factory|'s [=TrustedTypePolicyFactory/default policy=]
-    value is not null, throw a TypeError and abort further steps.
-1.  Let |policy| be a new {{TrustedTypePolicy}} object.
-1.  Set |policy|'s `name` property value to |policyName|.
-1.  Set |policy|'s [=TrustedTypePolicy/options=] value to «[
-      "createHTML" -> |options|["{{TrustedTypePolicyOptions/createHTML|createHTML}}"],
-      "createScript" -> |options|["{{TrustedTypePolicyOptions/createScript|createScript}}"],
-      "createScriptURL" -> |options|["{{TrustedTypePolicyOptions/createScriptURL|createScriptURL}}"],
-      "createParserOptions" -> |options|["{{TrustedTypePolicyOptions/createParserOptions|createParserOptions}}"]
-    ]».
-1.  If the |policyName| is `default`, set the |factory|'s [=TrustedTypePolicyFactory/default policy=] value to |policy|.
-1.  [=set/append|Append=] |policyName| to |factory|'s [=created policy names=].
-1.  Return |policy|.
-
-## Create a Trusted Type ## {#create-a-trusted-type-algorithm}
-
-To <dfn>create a trusted type</dfn> given a {{TrustedTypePolicy}} |policy|, a type name |trustedTypeName|,
-a string or dictionary |value| and a list |arguments|, perform the following steps:
-
-1.  Let |policyValue| be the result of executing [=get trusted type policy value=] with the same arguments as this algorithm and additionally true as |throwIfMissing|.
-1.  If the algorithm threw an error, rethrow the error and abort the following steps.
-1.  If |trustedTypeName| is `"TrustedHTMLParserOptions"`:
-    1.  If |policyValue| is not a [=dictionary=], throw a {{TypeError}}.
-    1.  Let |sanitizerConfig| be the result of
-        [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=]
-        from |policy|'s [=relevant realm=] and |policyValue|.
-    1.  Let |runScripts| be |policyValue|["runScripts"] [=with default=] false.
-    1.  Return a new instance of {{TrustedHTMLParserOptions}} in |policy|'s [=relevant realm=] with its
-        [=TrustedHTMLParserOptions/sanitizer configuration=] set to |sanitizerConfig|, and its
-        [=TrustedHTMLParserOptions/runScripts=] set to |runScripts|.
-1.  Let |dataString| be the result of stringifying |policyValue|.
-1.  If |policyValue| is null or undefined, set |dataString| to the empty string.
-1.  Return a new instance of an interface with a type
-    name |trustedTypeName|, with its associated data value set to |dataString|.
-
-## Get Trusted Type policy value ## {#get-trusted-type-policy-value-algorithm}
-
-To <dfn>get trusted type policy value</dfn> given a {{TrustedTypePolicy}} |policy|, a type name |trustedTypeName|,
-a string or dictionary |value|, a list |arguments|, and a boolean |throwIfMissing|, perform the following steps:
-
-1.  Let |functionName| be a function name for the given |trustedTypeName|,
-    based on the following table:
-
-    <table>
-      <tr>
-        <th>Function name</th>
-        <th>Trusted Type name </th>
-      </tr>
-      <tr>
-        <td>"createHTML"</td>
-        <td>"TrustedHTML"</td>
-      </tr>
-      <tr>
-        <td>"createScript"</td>
-        <td>"TrustedScript"</td>
-      </tr>
-      <tr>
-        <td>"createScriptURL"</td>
-        <td>"TrustedScriptURL"</td>
-      </tr>
-      <tr>
-        <td>"createParserOptions"</td>
-        <td>"TrustedHTMLParserOptions"</td>
-      </tr>
-    </table>
-
-1.  Let |function| be |policy|'s [=options=][|functionName|].
-1.  If |function| is `null`, then:
-    1. If |throwIfMissing| throw a TypeError.
-    1. Else return `null`.
-1.  Let |args| be « |value| ».
-1.  [=set/append|Append=] each item in |arguments| to |args|.
-1.  Let |policyValue| be the result of [=invoke|invoking=] |function| with
-    |args| and `"rethrow"`.
-1.  Return |policyValue|.
-
-## Get Trusted Type compliant input ## {#get-trusted-type-compliant-input-algorithm}
-
-To <dfn export>get trusted type compliant input</dfn> given a [=realm/global object=] |global|, a string or {{TrustedHTML}} |input|,
-a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, a string |sink|, and an optional `"html"` or `"xml"` |documentType| (default `"html"`):
-
-1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
-1. If |documentType| is `"html"`:
-    1. If |compliantOptions| is an instance of {{TrustedHTMLParserOptions}}, return (stringified |input|, |compliantOptions|).
-1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
-1. If the algorithm threw an error, rethrow the error.
-1. Return (|compliantHTML|, |compliantOptions|).
-
-<div class="note">
-<p>The following table summarizes the behavior of [=get trusted type compliant input=] for various combinations of arguments and default policy callbacks under enforcing Content Security Policy:</p>
+The following table summarizes the behavior of [=get trusted type compliant input=] for various combinations of arguments and default policy callbacks under enforcing Content Security Policy:
 
 <table class="data">
   <thead>
@@ -1442,7 +1345,108 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
   <li>In report-only mode or when Trusted Types enforcement is not required for the sink, a {{TypeError}} is not thrown on violation; instead, the original stringified |input| and |options| are returned.</li>
   <li>For streaming HTML fragment parsing, [=get trusted type compliant parser options=] is invoked directly with |throwIfMissing| set to true. In that context, if {{TrustedTypePolicyOptions/createParserOptions}} is missing, throws, or returns `null` or `undefined`, a {{TypeError}} is thrown (or rethrown) immediately.</li>
 </ul>
-</div>
+
+# Algorithms # {#algorithms}
+
+## Create a Trusted Type Policy ## {#create-trusted-type-policy-algorithm}
+
+To <dfn>create a trusted type policy</dfn>, given a {{TrustedTypePolicyFactory}} (|factory|),
+a string (|policyName|), {{TrustedTypePolicyOptions}} dictionary (|options|), and a
+[=realm/global object=] (|global|) run these steps:
+
+1.  Let |allowedByCSP| be the result of executing [=should Trusted Type policy
+    creation be blocked by content security policy?=] algorithm with |global|,
+    |policyName| and |factory|'s [=created policy names=] value.
+1.  If |allowedByCSP| is `"Blocked"`, throw a TypeError and abort further steps.
+1.  If |policyName| is `default` and the |factory|'s [=TrustedTypePolicyFactory/default policy=]
+    value is not null, throw a TypeError and abort further steps.
+1.  Let |policy| be a new {{TrustedTypePolicy}} object.
+1.  Set |policy|'s `name` property value to |policyName|.
+1.  Set |policy|'s [=TrustedTypePolicy/options=] value to «[
+      "createHTML" -> |options|["{{TrustedTypePolicyOptions/createHTML|createHTML}}"],
+      "createScript" -> |options|["{{TrustedTypePolicyOptions/createScript|createScript}}"],
+      "createScriptURL" -> |options|["{{TrustedTypePolicyOptions/createScriptURL|createScriptURL}}"],
+      "createParserOptions" -> |options|["{{TrustedTypePolicyOptions/createParserOptions|createParserOptions}}"]
+    ]».
+1.  If the |policyName| is `default`, set the |factory|'s [=TrustedTypePolicyFactory/default policy=] value to |policy|.
+1.  [=set/append|Append=] |policyName| to |factory|'s [=created policy names=].
+1.  Return |policy|.
+
+## Create a Trusted Type ## {#create-a-trusted-type-algorithm}
+
+To <dfn>create a trusted type</dfn> given a {{TrustedTypePolicy}} |policy|, a type name |trustedTypeName|,
+a string or dictionary |value| and a list |arguments|, perform the following steps:
+
+1.  Let |policyValue| be the result of executing [=get trusted type policy value=] with the same arguments as this algorithm and additionally true as |throwIfMissing|.
+1.  If the algorithm threw an error, rethrow the error and abort the following steps.
+1.  If |trustedTypeName| is `"TrustedHTMLParserOptions"`:
+    1.  If |policyValue| is not a [=dictionary=], throw a {{TypeError}}.
+    1.  Let |sanitizerConfig| be the result of
+        [=get a sanitizer config copy from dictionary|getting a sanitizer configuration=]
+        from |policy|'s [=relevant realm=] and |policyValue|.
+    1.  Let |runScripts| be |policyValue|["runScripts"] [=with default=] false.
+    1.  Return a new instance of {{TrustedHTMLParserOptions}} in |policy|'s [=relevant realm=] with its
+        [=TrustedHTMLParserOptions/sanitizer configuration=] set to |sanitizerConfig|, and its
+        [=TrustedHTMLParserOptions/runScripts=] set to |runScripts|.
+1.  Let |dataString| be the result of stringifying |policyValue|.
+1.  If |policyValue| is null or undefined, set |dataString| to the empty string.
+1.  Return a new instance of an interface with a type
+    name |trustedTypeName|, with its associated data value set to |dataString|.
+
+## Get Trusted Type policy value ## {#get-trusted-type-policy-value-algorithm}
+
+To <dfn>get trusted type policy value</dfn> given a {{TrustedTypePolicy}} |policy|, a type name |trustedTypeName|,
+a string or dictionary |value|, a list |arguments|, and a boolean |throwIfMissing|, perform the following steps:
+
+1.  Let |functionName| be a function name for the given |trustedTypeName|,
+    based on the following table:
+
+    <table>
+      <tr>
+        <th>Function name</th>
+        <th>Trusted Type name </th>
+      </tr>
+      <tr>
+        <td>"createHTML"</td>
+        <td>"TrustedHTML"</td>
+      </tr>
+      <tr>
+        <td>"createScript"</td>
+        <td>"TrustedScript"</td>
+      </tr>
+      <tr>
+        <td>"createScriptURL"</td>
+        <td>"TrustedScriptURL"</td>
+      </tr>
+      <tr>
+        <td>"createParserOptions"</td>
+        <td>"TrustedHTMLParserOptions"</td>
+      </tr>
+    </table>
+
+1.  Let |function| be |policy|'s [=options=][|functionName|].
+1.  If |function| is `null`, then:
+    1. If |throwIfMissing| throw a TypeError.
+    1. Else return `null`.
+1.  Let |args| be « |value| ».
+1.  [=set/append|Append=] each item in |arguments| to |args|.
+1.  Let |policyValue| be the result of [=invoke|invoking=] |function| with
+    |args| and `"rethrow"`.
+1.  Return |policyValue|.
+
+## Get Trusted Type compliant input ## {#get-trusted-type-compliant-input-algorithm}
+
+Note: See [[#summary-of-input-enforcement]] for a summary of this algorithm's behavior for various combinations of arguments and default policy callbacks.
+
+To <dfn export>get trusted type compliant input</dfn> given a [=realm/global object=] |global|, a string or {{TrustedHTML}} |input|,
+a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOptions}} |options|, a string |sink|, and an optional `"html"` or `"xml"` |documentType| (default `"html"`):
+
+1. Let |compliantOptions| be the result of calling [=get trusted type compliant parser options=], passing |global|, |options|, false, and |sink|.
+1. If |documentType| is `"html"`:
+    1. If |compliantOptions| is an instance of {{TrustedHTMLParserOptions}}, return (stringified |input|, |compliantOptions|).
+1. Let |compliantHTML| be the result of calling [=get trusted type compliant string=], passing {{TrustedHTML}}, |global|, |input|, |sink|, and `"script"`.
+1. If the algorithm threw an error, rethrow the error.
+1. Return (|compliantHTML|, |compliantOptions|).
 
 ## Get Trusted Type compliant string ## {#get-trusted-type-compliant-string-algorithm}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1303,6 +1303,109 @@ a {{TrustedHTMLParserOptions}}, {{ParseHTMLUnsafeOptions}} or {{SetHTMLUnsafeOpt
 1. If the algorithm threw an error, rethrow the error.
 1. Return (|compliantHTML|, |compliantOptions|).
 
+<p class="note">The following table summarizes the behavior of [=get trusted type compliant input=] for various combinations of arguments and default policy callbacks under enforcing Content Security Policy:</p>
+
+<table class="data">
+  <thead>
+    <tr>
+      <th>|documentType|</th>
+      <th>|options|</th>
+      <th>|input|</th>
+      <th>Default policy state / callback</th>
+      <th>Result</th>
+      <th>Rationale</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`"html"`</td>
+      <td>{{TrustedHTMLParserOptions}}</td>
+      <td>String or {{TrustedHTML}}</td>
+      <td>(Ignored)</td>
+      <td>Returns `(stringified |input|, |options|)`.</td>
+      <td>Caller-supplied {{TrustedHTMLParserOptions}} explicitly authorizes the parse operation, satisfying Trusted Types for the sink.</td>
+    </tr>
+    <tr>
+      <td rowspan="3">`"html"`</td>
+      <td rowspan="3">Dictionary</td>
+      <td rowspan="3">String or {{TrustedHTML}}</td>
+      <td>{{TrustedTypePolicyOptions/createParserOptions}} returns a dictionary</td>
+      <td>Returns `(stringified |input|, |compliantOptions|)`.</td>
+      <td>The default policy creates a {{TrustedHTMLParserOptions}} to configure the parser (such as setting a sanitizer or disable script execution), authorizing the sink.</td>
+    </tr>
+    <tr>
+      <td>{{TrustedTypePolicyOptions/createParserOptions}} throws an exception</td>
+      <td>Rethrows the exception.</td>
+      <td>Exceptions in policy callbacks propagate immediately to the caller.</td>
+    </tr>
+    <tr>
+      <td>{{TrustedTypePolicyOptions/createParserOptions}} returns `null` or `undefined`</td>
+      <td>Throws a {{TypeError}}.</td>
+      <td>Returning null or undefined from a policy callback rejects the value, triggering a CSP violation error.</td>
+    </tr>
+    <tr>
+      <td>`"html"`</td>
+      <td>Dictionary</td>
+      <td>{{TrustedHTML}}</td>
+      <td>No {{TrustedTypePolicyOptions/createParserOptions}} (or no default policy)</td>
+      <td>Returns `(stringified |input|, |options|)`.</td>
+      <td>When options are not vetted by a policy, the sink checks the markup; an existing {{TrustedHTML}} instance satisfies this check.</td>
+    </tr>
+    <tr>
+      <td rowspan="4">`"html"`</td>
+      <td rowspan="4">Dictionary</td>
+      <td rowspan="4">String</td>
+      <td>No {{TrustedTypePolicyOptions/createParserOptions}}; {{TrustedTypePolicyOptions/createHTML}} returns {{TrustedHTML}}</td>
+      <td>Returns `(stringified |convertedInput|, |options|)`.</td>
+      <td>Provides backwards compatibility: when no policy manages parser options, the sink falls back to vetting or sanitizing the markup string via {{TrustedTypePolicyOptions/createHTML}}.</td>
+    </tr>
+    <tr>
+      <td>No {{TrustedTypePolicyOptions/createParserOptions}}; {{TrustedTypePolicyOptions/createHTML}} throws an exception</td>
+      <td>Rethrows the exception.</td>
+      <td>Exceptions in policy callbacks propagate immediately to the caller.</td>
+    </tr>
+    <tr>
+      <td>No {{TrustedTypePolicyOptions/createParserOptions}}; {{TrustedTypePolicyOptions/createHTML}} returns `null` or `undefined`</td>
+      <td>Throws a {{TypeError}}.</td>
+      <td>Rejection by {{TrustedTypePolicyOptions/createHTML}} triggers a CSP violation error.</td>
+    </tr>
+    <tr>
+      <td>No default policy (or neither callback defined)</td>
+      <td>Throws a {{TypeError}}.</td>
+      <td>Under enforcing CSP, a raw string cannot be parsed without a policy authorizing either the parser options or the markup string.</td>
+    </tr>
+    <tr>
+      <td>`"xml"`</td>
+      <td>Any</td>
+      <td>{{TrustedHTML}}</td>
+      <td>(Any)</td>
+      <td>Returns `(stringified |input|, |options|)`.</td>
+      <td>XML sinks require trusted markup; a {{TrustedHTML}} instance satisfies this requirement directly.</td>
+    </tr>
+    <tr>
+      <td rowspan="3">`"xml"`</td>
+      <td rowspan="3">Any</td>
+      <td rowspan="3">String</td>
+      <td>{{TrustedTypePolicyOptions/createHTML}} returns {{TrustedHTML}}</td>
+      <td>Returns `(stringified |convertedInput|, |options|)`.</td>
+      <td>XML fragment sinks do not support parser options bypass or sanitization; markup strings must always be converted via {{TrustedTypePolicyOptions/createHTML}}.</td>
+    </tr>
+    <tr>
+      <td>{{TrustedTypePolicyOptions/createHTML}} throws an exception</td>
+      <td>Rethrows the exception.</td>
+      <td>Exceptions in policy callbacks propagate immediately to the caller.</td>
+    </tr>
+    <tr>
+      <td>No {{TrustedTypePolicyOptions/createHTML}} or no default policy (or returns `null`/`undefined`)</td>
+      <td>Throws a {{TypeError}}.</td>
+      <td>Untrusted strings cannot be injected into XML sinks without {{TrustedTypePolicyOptions/createHTML}}, regardless of parser options.</td>
+    </tr>
+  </tbody>
+</table>
+
+<p class="note">In report-only mode or when Trusted Types enforcement is not required for the sink, a {{TypeError}} is not thrown on violation; instead, the original stringified |input| and |options| are returned.<br>
+For streaming HTML fragment parsing, [=get trusted type compliant parser options=] is invoked directly with |throwIfMissing| set to true. In that context, if {{TrustedTypePolicyOptions/createParserOptions}} is missing, throws, or returns `null` or `undefined`, a {{TypeError}} is thrown (or rethrown) immediately.</p>
+
 ## Get Trusted Type compliant string ## {#get-trusted-type-compliant-string-algorithm}
 
 This algorithm will return a string that can be used with an


### PR DESCRIPTION
`createParserOptions` receives an optional `SetHTMLUnsafeOptions` dictionary (or `ParseHTMLUnsafeOptions`) and turns it into a `TrustedHTMLParserOptions` object using the `createParserOptions` method defined on the policy.

In modern browsers supporting this method, `createParserOptions` serves as the primary Trusted Types mechanism for HTML fragment parsing sinks (`setHTMLUnsafe`, `innerHTML`, `outerHTML`, `insertAdjacentHTML`, and `createContextualFragment`), allowing a policy to configure a `Sanitizer` and/or disallow script execution:
- **Caller-supplied:** Passing a `TrustedHTMLParserOptions` object directly into a fragment parsing sink satisfies Trusted Types enforcement for HTML documents, allowing raw markup strings to be parsed without requiring a `TrustedHTML` object or invoking `createHTML`.
- **Default policy:** When a default policy defines `createParserOptions`, calls to fragment parsing sinks automatically produce a `TrustedHTMLParserOptions` that satisfies the sink, applying the policy's sanitizer and script-execution settings. Note that the default policy takes precedence even if less restrictive than the caller - it can vet a less restrictive sanitizer, or enable script execution.
- **Fallback to `createHTML`:** If no `TrustedHTMLParserOptions` is provided (either by the caller or via a default policy's `createParserOptions`), we fall back to the existing `get trusted type compliant string`, requiring `input` to be a `TrustedHTML` or passing it to the default policy's `createHTML`. This ensures backwards compatibility for policies that only define `createHTML`, and covers string-only sinks that do not support parser options (e.g. `document.write()` and `iframe.srcdoc`). Note that `TrustedHTML` does not receive special handling when `createParserOptions` is present in the policy - in supported browsers/sinks, `createHTML` and `TrustedHTML` are a fallback only.
- **Streaming HTML:** For sinks where the full HTML is not available up front (such as streaming parsing), `get trusted type compliant parser options` is invoked with `throwIfMissing = true`, requiring the caller to supply a `TrustedHTMLParserOptions` or requiring the default policy to define `createParserOptions`.

### Key Design Choices & Semantics:
- **Opaque interface:** `TrustedHTMLParserOptions` does not expose any interface methods or attributes to JavaScript; it acts as an immutable, opaque token whose internal associated configuration and script-execution settings are inspected directly by specification algorithms.
- **XML documents:** For XML fragment parsing (`documentType` is `"xml"`), `TrustedHTMLParserOptions` does not bypass `createHTML`; compliant string input (`TrustedHTML` or `createHTML`) is always required.
- **Security model:** As documented in the Security Considerations, a `createParserOptions` callback that does not configure a sanitizer to remove unsafe markup (e.g. scripts or event handlers) grants a pass-through to parse arbitrary markup without DOM XSS protection. It is the responsibility of the policy author / security auditor to ensure `createParserOptions` enforces adequate sanitization, or that a `TrustedHTMLParserOptions` object is only passed to trusted source (similar to the policy objects themselves).


As a followup, we should evaluate the (existing) combination of `TrustedHTML` with sanitizer. Opened #615 for that.

This is the `trusted-types` part of #594 together with https://github.com/whatwg/html/pull/12583.
Note that this should only be merged when wired into the HTML standard, once the sanitizer is itself upstreamed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/pull/606.html" title="Last updated on Sep 8, 2026, 12:46 PM UTC (b8ce5b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/606/d92fbe8...b8ce5b9.html" title="Last updated on Sep 8, 2026, 12:46 PM UTC (b8ce5b9)">Diff</a>