### PR TITLE
Fix build errors.

### DIFF
--- a/.github/workflows/generate-spec.yml
+++ b/.github/workflows/generate-spec.yml
@@ -13,7 +13,7 @@ jobs:
     name: Generate spec
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: w3c/spec-prod@v2
         with:
           TOOLCHAIN: bikeshed

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1352,7 +1352,7 @@ The {{HTMLScriptElement/src}} getter steps are:
 
 1. <ins>If |urlString| is not failure, then return |urlString|.</ins>
 
-1. <ins>Return |contentAttributeValue|, converted to a scalar value string.
+1. <ins>Return |contentAttributeValue|, converted to a scalar value string.</ins>
 
 The {{HTMLScriptElement/src}} setter steps are:
 
@@ -1544,7 +1544,7 @@ The <dfn export>does sink type require trusted types?</dfn> algorithm, given a [
         is `"require-trusted-types-for"`
     1.  If |directive|'s [=directive/value=] does not contain a <a>trusted-types-sink-group</a> which is a match
         for |sinkGroup|, skip to the next |policy|.
-    1.  Let |enforced| be true if |policy|'s [=policy/disposition=] is `"enforce"`, and false otherwise.
+    1.  Let |enforced| be true if |policy|'s [=content security policy object/disposition=] is `"enforce"`, and false otherwise.
     1.  If |enforced| is true, return true.
     1.  If |includeReportOnlyPolicies| is true, return true.
 1. Return false.
@@ -1576,7 +1576,7 @@ The <dfn>should sink type mismatch violation be blocked by content security poli
     1. Let |trimmedSample| be the substring of |sample|, containing its first 40 characters.
     1. Set |violation|'s [=violation/sample=] to be the result of [=concatenating=] the list &laquo; |sink|, |trimmedSample| &laquo; using `"|"` as a separator.
     1.  Execute [[CSP#report-violation|Report a violation]] on |violation|.
-    1.  If |policy|'s [=policy/disposition=] is `"enforce"`, then set |result| to
+    1.  If |policy|'s [=content security policy object/disposition=] is `"enforce"`, then set |result| to
         `"Blocked"`.
 1. Return |result|.
 
@@ -1616,7 +1616,7 @@ strings (|createdPolicyNames|), performs the following steps:
     1. Set |violation|'s [=violation/resource=] to `"trusted-types-policy"`.
     1. Set |violation|'s [=violation/sample=] to the substring of |policyName|, containing its first 40 characters.
     1.  Execute [[CSP#report-violation|Report a violation]] on |violation|.
-    1.  If |policy|'s [=policy/disposition=] is `"enforce"`, then set |result| to
+    1.  If |policy|'s [=content security policy object/disposition=] is `"enforce"`, then set |result| to
         `"Blocked"`.
 1. Return |result|.
 


### PR DESCRIPTION
The current spec doesn't seem to succesfully build anymore:
https://github.com/w3c/trusted-types/actions/runs/24479742864/job/71541120919

* Close the \<ins> element.
* Fix references to CSP's disposition.
* Update checkout action to current version.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/trusted-types/pull/610.html" title="Last updated on Jun 23, 2026, 11:47 AM UTC (a50cc07)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trusted-types/610/25fd9fb...otherdaniel:a50cc07.html" title="Last updated on Jun 23, 2026, 11:47 AM UTC (a50cc07)">Diff</a>